### PR TITLE
Enable packet create #5

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -195,6 +195,8 @@ func getProvisioner(provider, accessToken, secretKey, organisationID, region str
 		return provision.NewDigitalOceanProvisioner(accessToken)
 	} else if provider == "scaleway" {
 		return provision.NewScalewayProvisioner(accessToken, secretKey, organisationID, region)
+	} else if provider == "packet" {
+		return provision.NewPacketProvisioner(accessToken)
 	}
 	return nil, fmt.Errorf("no provisioner for provider: %s", provider)
 }
@@ -219,6 +221,15 @@ func createHost(provider, name, region, userData string) (*provision.BasicHost, 
 			Name:       name,
 			OS:         "ubuntu-bionic",
 			Plan:       "DEV1-S",
+			Region:     region,
+			UserData:   userData,
+			Additional: map[string]string{},
+		}, nil
+	} else if provider == "packet" {
+		return &provision.BasicHost{
+			Name:       name,
+			OS:         "ubuntu_16_04",
+			Plan:       "baremetal_0",
 			Region:     region,
 			UserData:   userData,
 			Additional: map[string]string{},


### PR DESCRIPTION
## Description

fixes #5 
I added to enable create/delete `packet.com` provisioner.

## How Has This Been Tested?
only `make dist`
## How are existing users impacted? What migration steps/scripts do we need?
May be nothing

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
not required
- [o] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [o] signed-off my commits with `git commit -s`
- [ ] added unit tests

First of all, this repository doesn't have any unit tests or system(combined) tests at all.
Anyway I executed `make dist` to check whether it can be build or not.