### PR TITLE
Add Civo as a provider to inletsctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Completed:
 * [x] DigitalOcean support
 * [x] Scaleway support
 * [x] `inletsctl delete` command
+* [x] Add Civo.com
+* [x] Add poll interval `--poll 5s` for use with Civo that applies rate-limiting
 
 Pending:
 

--- a/pkg/civo.go
+++ b/pkg/civo.go
@@ -1,0 +1,151 @@
+package pkg
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+
+	"strings"
+	"time"
+
+	"github.com/inlets/inlets-operator/pkg/provision"
+)
+
+// CivoProvisioner creates instances on civo.com
+type CivoProvisioner struct {
+	APIKey string
+}
+
+// NewCivoProvisioner with an accessKey
+func NewCivoProvisioner(accessKey string) (*CivoProvisioner, error) {
+
+	return &CivoProvisioner{
+		APIKey: accessKey,
+	}, nil
+}
+
+func (p *CivoProvisioner) Status(id string) (*provision.ProvisionedHost, error) {
+	host := &provision.ProvisionedHost{}
+
+	apiURL := fmt.Sprint("https://api.civo.com/v2/instances/", id)
+
+	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+	if err != nil {
+		return host, err
+	}
+	addAuth(req, p.APIKey)
+
+	req.Header.Add("Accept", "application/json")
+	instance := CreatedInstance{}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return host, err
+	}
+
+	var body []byte
+	if res.Body != nil {
+		defer res.Body.Close()
+		body, _ = ioutil.ReadAll(res.Body)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return host, fmt.Errorf("unexpected HTTP code: %d\n%q", res.StatusCode, string(body))
+	}
+
+	unmarshalErr := json.Unmarshal(body, &instance)
+	if unmarshalErr != nil {
+		return host, unmarshalErr
+	}
+
+	return &provision.ProvisionedHost{
+		ID:     instance.ID,
+		IP:     instance.PublicIP,
+		Status: strings.ToLower(instance.Status),
+	}, nil
+}
+
+func (p *CivoProvisioner) Delete(id string) error {
+	return nil
+}
+
+func (p *CivoProvisioner) Provision(host provision.BasicHost) (*provision.ProvisionedHost, error) {
+
+	log.Printf("Provisioning host with Civo\n")
+
+	if host.Region == "" {
+		host.Region = "lon1"
+	}
+
+	res, err := provisionCivoInstance(host, p.APIKey)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &provision.ProvisionedHost{
+		ID: res.ID,
+	}, nil
+}
+
+func provisionCivoInstance(host provision.BasicHost, key string) (CreatedInstance, error) {
+	instance := CreatedInstance{}
+
+	apiURL := "https://api.civo.com/v2/instances"
+
+	values := url.Values{}
+	values.Add("hostname", host.Name)
+	values.Add("size", host.Plan)
+	values.Add("public_ip", "true")
+	values.Add("template_id", host.OS)
+	values.Add("initial_user", "civo")
+	values.Add("script", host.UserData)
+	values.Add("script", "inlets")
+
+	req, err := http.NewRequest(http.MethodPost, apiURL, strings.NewReader(values.Encode()))
+	if err != nil {
+		return instance, err
+	}
+	addAuth(req, key)
+
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return instance, err
+	}
+
+	var body []byte
+	if res.Body != nil {
+		defer res.Body.Close()
+		body, _ = ioutil.ReadAll(res.Body)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return instance, fmt.Errorf("unexpected HTTP code: %d\n%q", res.StatusCode, string(body))
+	}
+
+	unmarshalErr := json.Unmarshal(body, &instance)
+	if unmarshalErr != nil {
+		return instance, unmarshalErr
+	}
+
+	fmt.Printf("Instance ID: %s\n", instance.ID)
+	return instance, nil
+}
+
+type CreatedInstance struct {
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	PublicIP  string    `json:"public_ip"`
+	Status    string    `json:"status"`
+}
+
+func addAuth(r *http.Request, APIKey string) {
+	r.Header.Add("Authorization", fmt.Sprintf("bearer %s", APIKey))
+	r.Header.Add("User-Agent", "inlets")
+}

--- a/pkg/civo.go
+++ b/pkg/civo.go
@@ -69,6 +69,37 @@ func (p *CivoProvisioner) Status(id string) (*provision.ProvisionedHost, error) 
 }
 
 func (p *CivoProvisioner) Delete(id string) error {
+
+	apiURL := fmt.Sprint("https://api.civo.com/v2/instances/", id)
+
+	req, err := http.NewRequest(http.MethodDelete, apiURL, nil)
+	if err != nil {
+		return err
+	}
+	addAuth(req, p.APIKey)
+
+	req.Header.Add("Accept", "application/json")
+	instance := CreatedInstance{}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	var body []byte
+	if res.Body != nil {
+		defer res.Body.Close()
+		body, _ = ioutil.ReadAll(res.Body)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected HTTP code: %d\n%q", res.StatusCode, string(body))
+	}
+
+	unmarshalErr := json.Unmarshal(body, &instance)
+	if unmarshalErr != nil {
+		return unmarshalErr
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Description

Add Civo as a provider to inletsctl

Closes #6 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Create

```
./inletsctl create --provider civo --access-token $CIVO_ACCESS_TOKEN --poll 10s
Using provider: civo
Requesting host: vigilant-elgamal2 in , from civo
2019/11/07 21:14:17 Provisioning host with Civo
Instance ID: fd9319ab-f6e8-4165-b65a-f51b6739d83f
Host: fd9319ab-f6e8-4165-b65a-f51b6739d83f, status: 
[1/500] Host: fd9319ab-f6e8-4165-b65a-f51b6739d83f, status: build
[2/500] Host: fd9319ab-f6e8-4165-b65a-f51b6739d83f, status: build
[3/500] Host: fd9319ab-f6e8-4165-b65a-f51b6739d83f, status: build
[4/500] Host: fd9319ab-f6e8-4165-b65a-f51b6739d83f, status: build
[5/500] Host: fd9319ab-f6e8-4165-b65a-f51b6739d83f, status: active
Inlets OSS exit-node summary:
  IP: 91.211.153.202
  Auth-token: u9i3DjK3NY7U6NT3Je5e9AUUUyvqNltNFdjZuuYWpIs8eRJPHY9NfdzxUwSUtqUY

Command:
  export UPSTREAM=http://127.0.0.1:8000
  inlets client --remote "ws://91.211.153.202:8080" \
        --token "u9i3DjK3NY7U6NT3Je5e9AUUUyvqNltNFdjZuuYWpIs8eRJPHY9NfdzxUwSUtqUY" \
        --upstream $UPSTREAM
Inlets OSS exit-node summary:
  IP: 91.211.153.202
  Auth-token: u9i3DjK3NY7U6NT3Je5e9AUUUyvqNltNFdjZuuYWpIs8eRJPHY9NfdzxUwSUtqUY

Command:
  export UPSTREAM=http://127.0.0.1:8000
  inlets client --remote "ws://91.211.153.202:8080" \
        --token "u9i3DjK3NY7U6NT3Je5e9AUUUyvqNltNFdjZuuYWpIs8eRJPHY9NfdzxUwSUtqUY" \
        --upstream $UPSTREAM
```

Delete

```
./inletsctl delete --id fd9319ab-f6e8-4165-b65a-f51b6739d83f --provider civo --access-token $CIVO_API_TOKEN

Using provider: civo
Deleting host: fd9319ab-f6e8-4165-b65a-f51b6739d83f from civo
```

I noted that:

* Civo rate-limited us when checking every 1-2 seconds, so I added a `--poll 10s` option
* Civo's API gave 200 instead of the documented 202 for deleting an instance: https://www.civo.com/api/instances#deleting-an-instance
* No current Golang API exists, so I've written custom code to provide this

## Future work

This will need to be added to the inlets-operator next to use Civo with the Kubernetes operator.
