### PR TITLE
Add packet as provider

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -23,7 +23,6 @@ func init() {
 	deleteCmd.Flags().String("secret-key", "", "The access token for your cloud (Scaleway)")
 	deleteCmd.Flags().String("secret-key-file", "", "Read this file for the access token for your cloud (Scaleway)")
 	deleteCmd.Flags().String("organisation-id", "", "Organisation ID (Scaleway)")
-
 }
 
 // clientCmd represents the client sub command.

--- a/vendor/github.com/packethost/packngo/go.mod
+++ b/vendor/github.com/packethost/packngo/go.mod
@@ -5,3 +5,5 @@ require (
 	golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67
 	golang.org/x/sys v0.0.0-20190209173611-3b5209105503 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description

Add [packet.com](https://packet.com/) as provider

## How Has This Been Tested?

This commit adds packet.com as a provisioner which is already
available in the upstream package, but wasn't exposed via flags
or code. Tested e2e with the ewr1 region including create and
delete.

Closes #5 #7 

## How are existing users impacted? What migration steps/scripts do we need?

Tested e2e, I'm aware of no impact, just more choice.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
