### PR TITLE
Add kfwd command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: go
 
 go:
-- 1.11.x
+- 1.12.x
 
 script:
 - make dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 sudo: required
 language: go
+
 go:
-- '1.11'
+- 1.11.x
+
 script:
 - make dist
+
 before_deploy:
 - "./ci/hashgen.sh"
 
@@ -25,3 +28,6 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
+
+env:
+  - GO111MODULE=off

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:72e7e0f8fdddb762535bc00934efb311db71d5ccdb4076128bac4b68f3e08e7d"
+  name = "github.com/alexellis/go-execute"
+  packages = ["pkg/v1"]
+  pruneopts = "UT"
+  revision = "d17947259f74333b6272fb04c809d5e6df7709a8"
+  version = "0.2.1"
+
+[[projects]]
   digest = "1:5bd74021baf638b4e3493a6832c89ee554058154d17e14d2f5a5345013f5f703"
   name = "github.com/digitalocean/godo"
   packages = ["."]
@@ -151,6 +159,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/alexellis/go-execute/pkg/v1",
     "github.com/digitalocean/godo",
     "github.com/morikuni/aec",
     "github.com/packethost/packngo",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,30 +1,3 @@
-# Gopkg.toml example
-#
-# Refer to https://golang.github.io/dep/docs/Gopkg.toml.html
-# for detailed Gopkg.toml documentation.
-#
-# required = ["github.com/user/thing/cmd/thing"]
-# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-#
-# [[constraint]]
-#   name = "github.com/user/project"
-#   version = "1.0.0"
-#
-# [[constraint]]
-#   name = "github.com/user/project2"
-#   branch = "dev"
-#   source = "github.com/myfork/project2"
-#
-# [[override]]
-#   name = "github.com/x/y"
-#   version = "2.4.0"
-#
-# [prune]
-#   non-go = false
-#   go-tests = true
-#   unused-packages = true
-
-
 [[constraint]]
   name = "github.com/digitalocean/godo"
   version = "1.27.0"
@@ -60,6 +33,10 @@
 [[constraint]]
   branch = "master"
   name = "golang.org/x/oauth2"
+
+[[constraint]]
+  name = "github.com/alexellis/go-execute"
+  version = "0.2.1"
 
 [prune]
   go-tests = true

--- a/vendor/github.com/alexellis/go-execute/LICENSE
+++ b/vendor/github.com/alexellis/go-execute/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Inlets
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/alexellis/go-execute/pkg/v1/exec.go
+++ b/vendor/github.com/alexellis/go-execute/pkg/v1/exec.go
@@ -1,0 +1,113 @@
+package execute
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type ExecTask struct {
+	Command string
+	Args    []string
+	Shell   bool
+	Env     []string
+	Cwd     string
+}
+
+type ExecResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+func (et ExecTask) Execute() (ExecResult, error) {
+	argsSt := ""
+	if len(et.Args) > 0 {
+		argsSt = strings.Join(et.Args, " ")
+	}
+
+	fmt.Println("exec: ", et.Command, argsSt)
+
+	var cmd *exec.Cmd
+
+	if et.Shell {
+		var args []string
+		if len(et.Args) == 0 {
+			startArgs := strings.Split(et.Command, " ")
+			script := strings.Join(startArgs, " ")
+			args = append([]string{"-c"}, fmt.Sprintf("%s", script))
+
+		} else {
+			script := strings.Join(et.Args, " ")
+			args = append([]string{"-c"}, fmt.Sprintf("%s %s", et.Command, script))
+
+		}
+
+		cmd = exec.Command("/bin/bash", args...)
+	} else {
+		if strings.Index(et.Command, " ") > 0 {
+			parts := strings.Split(et.Command, " ")
+			command := parts[0]
+			args := parts[1:]
+			cmd = exec.Command(command, args...)
+
+		} else {
+			cmd = exec.Command(et.Command, et.Args...)
+		}
+	}
+
+	cmd.Dir = et.Cwd
+
+	if len(et.Env) > 0 {
+		cmd.Env = os.Environ()
+		for _, env := range et.Env {
+			cmd.Env = append(cmd.Env, env)
+		}
+	}
+
+	stdoutPipe, stdoutPipeErr := cmd.StdoutPipe()
+	if stdoutPipeErr != nil {
+		return ExecResult{}, stdoutPipeErr
+	}
+
+	stderrPipe, stderrPipeErr := cmd.StderrPipe()
+	if stderrPipeErr != nil {
+		return ExecResult{}, stderrPipeErr
+	}
+
+	startErr := cmd.Start()
+
+	if startErr != nil {
+		return ExecResult{}, startErr
+	}
+
+	stdoutBytes, err := ioutil.ReadAll(stdoutPipe)
+	if err != nil {
+		return ExecResult{}, err
+	}
+
+	stderrBytes, err := ioutil.ReadAll(stderrPipe)
+
+	if err != nil {
+		return ExecResult{}, err
+	}
+
+	fmt.Println("res: " + string(stdoutBytes))
+
+	exitCode := 0
+	execErr := cmd.Wait()
+	if execErr != nil {
+		if exitError, ok := execErr.(*exec.ExitError); ok {
+
+			exitCode = exitError.ExitCode()
+		}
+	}
+
+	return ExecResult{
+		Stdout:   string(stdoutBytes),
+		Stderr:   string(stderrBytes),
+		ExitCode: exitCode,
+	}, nil
+}


### PR DESCRIPTION

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description

Add kfwd command

Makes the kubectl port-forward easier for minikube, KinD and k3d.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in this video between a local k3d cluster and my helm chart for the expressjs-k8s web server https://youtu.be/Suubz0f0p3c

```sh
curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash

helm repo add expressjs-k8s https://alexellis.github.io/expressjs-k8s/
helm repo update
helm install test-app expressjs-k8s/expressjs-k8s
```

Replace 192.168.0.14 with the ip found in `ifconfig` or your network settings. Use your ethernet or WiFi adapter IP.

```sh
inletsctl kfwd --from test-app-expressjs-k8s:8080 --if 192.168.0.14
```

Now access the service on: `http://192.168.0.14:8080`

## How are existing users impacted? What migration steps/scripts do we need?

N/a
