### PR TITLE
Fix hardcoded value of zone for GCE

### DIFF
--- a/pkg/provision/gce.go
+++ b/pkg/provision/gce.go
@@ -32,7 +32,7 @@ func (gce *GCEProvisioner) Provision(host BasicHost) (*ProvisionedHost, error) {
 		Description:  "Exit node created by inlets-operator",
 		MachineType:  fmt.Sprintf("zones/%s/machineTypes/%s", host.Additional["zone"], host.Plan),
 		CanIpForward: true,
-		Zone:         fmt.Sprintf("projects/%s/zones/us-central1-a", host.Additional["projectid"]),
+		Zone:         fmt.Sprintf("projects/%s/zones/%s", host.Additional["projectid"], host.Additional["zone"]),
 		Disks: []*compute.AttachedDisk{
 			{
 				AutoDelete: true,


### PR DESCRIPTION
Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

## Description
Fix the harcoded value of zone for the GCE provisioner

## How are existing users impacted? What migration steps/scripts do we need?
Now users will be able to override the default value of zone for the exit node

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
