### PR TITLE
Add output to create command for deletion of exit node

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -177,8 +177,11 @@ Command:
   inlets client --remote "ws://%s:%d" \
 	--token "%s" \
 	--upstream $UPSTREAM
+
+To Delete:
+  inletsctl delete --provider %s --id "%s"
 `,
-					hostStatus.IP, inletsToken, hostStatus.IP, inletsControlPort, inletsToken)
+					hostStatus.IP, inletsToken, hostStatus.IP, inletsControlPort, inletsToken, provider, hostStatus.ID)
 				return nil
 			}
 


### PR DESCRIPTION
## Description

The create command will not output the delete command for the exit node
that was just created. Related to #2 

## How Has This Been Tested?
I have tested with all providers except packet.

```
Using provider: digitalocean
Requesting host: angry-archimedes1 in , from digitalocean
2020/01/03 14:14:44 Provisioning host with DigitalOcean
Host: 174061244, status:
[1/500] Host: 174061244, status: new
[2/500] Host: 174061244, status: new
[3/500] Host: 174061244, status: new
[4/500] Host: 174061244, status: new
[5/500] Host: 174061244, status: new
[6/500] Host: 174061244, status: new
[7/500] Host: 174061244, status: new
[8/500] Host: 174061244, status: new
[9/500] Host: 174061244, status: new
[10/500] Host: 174061244, status: new
[11/500] Host: 174061244, status: active
Inlets OSS exit-node summary:
  IP: 157.245.41.205
  Auth-token: RgsuIGVPhiPuO6e67MvYOU2o4abwSzVc4zUCCO4sx4XCLxNwrbpj6oqSPAFMI6Cr

Command:
  export UPSTREAM=http://127.0.0.1:8000
  inlets client --remote "ws://157.245.41.205:8080" \
	--token "RgsuIGVPhiPuO6e67MvYOU2o4abwSzVc4zUCCO4sx4XCLxNwrbpj6oqSPAFMI6Cr" \
	--upstream $UPSTREAM

To Delete:
  inletsctl delete --provider digitalocean --id "174061244"
```

## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
