### PR TITLE
Add ability to delete using ip address

### DIFF
--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -1,19 +1,23 @@
 package provision
 
+// Provisioner is an interface used for deploying exit nodes into cloud providers
 type Provisioner interface {
 	Provision(BasicHost) (*ProvisionedHost, error)
 	Status(id string) (*ProvisionedHost, error)
-	Delete(id string) error
+	Delete(HostDeleteRequest) error
 }
 
+// ActiveStatus is the status returned by an active exit node
 const ActiveStatus = "active"
 
+// ProvisionedHost contains the IP, ID and Status of an exit node
 type ProvisionedHost struct {
 	IP     string
 	ID     string
 	Status string
 }
 
+// BasicHost contains the data required to deploy a exit node
 type BasicHost struct {
 	Region     string
 	Plan       string
@@ -21,4 +25,19 @@ type BasicHost struct {
 	Name       string
 	UserData   string
 	Additional map[string]string
+}
+
+// HostDeleteRequest contains the data required to delete an exit node by either IP or ID
+type HostDeleteRequest struct {
+	ID        string
+	IP        string
+	ProjectID string
+	Zone      string
+}
+
+// ListFilter is used to filter results to return only exit nodes
+type ListFilter struct {
+	Filter    string
+	ProjectID string
+	Zone      string
 }


### PR DESCRIPTION
## Description
I added lookup functions for each provisioner that list nodes based on tag/label where the provisioner supports it and then uses the ip to get the id of the node which is used to then delete it.  

Related to #2 

## How Has This Been Tested?
I created an exit node and then deleted it using every provider.

### Packet
Create
```
$ inletsctl create --provider packet --access-token $TOKEN --project-id $ID
Using provider: packet
Requesting host: quizzical-cori9 in ams1, from packet
Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status:
[1/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[2/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[3/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[4/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[5/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[6/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[7/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[8/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[9/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[10/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[11/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[12/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[13/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[14/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[15/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[16/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[17/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[18/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[19/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[20/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[21/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[22/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[23/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[24/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[25/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[26/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[27/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[28/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[29/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[30/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[31/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[32/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[33/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[34/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: provisioning
[35/500] Host: 8ac3919c-74a1-483c-aa75-e97ce7e0549f, status: active
Inlets OSS exit-node summary:
  IP: 147.75.33.63
  Auth-token: iEFLD5InJxVNkUb5NcAawyO95IdZApWdftmBCUMW8GtGvv4pkfmY0L4jP4Zfs2JX

Command:
  export UPSTREAM=http://127.0.0.1:8000
  inlets client --remote "ws://147.75.33.63:8080" \
	--token "iEFLD5InJxVNkUb5NcAawyO95IdZApWdftmBCUMW8GtGvv4pkfmY0L4jP4Zfs2JX" \
	--upstream $UPSTREAM
```
Delete
```
$ inletsctl delete  --provider packet --access-token $TOKEN --project-id $ID --ip 147.75.33.63
Using provider: packet
Deleting host: 147.75.33.63 from packet
```
Run delete again
```
inletsctl delete  --provider packet --access-token $TOKEN --project-id $ID --ip 147.75.33.63
Using provider: packet
Deleting host: 147.75.33.63 from packet
No host with ip: 147.75.33.63
```

### DigitalOcean
Create
```
$ inletsctl create -provider digitalocean --access-token $TOKEN
Using provider: digitalocean
Requesting host: zealous-vaughan7 in , from digitalocean
2020/01/04 12:33:49 Provisioning host with DigitalOcean
Host: 174177971, status:
[1/500] Host: 174177971, status: new
[2/500] Host: 174177971, status: new
[3/500] Host: 174177971, status: new
[4/500] Host: 174177971, status: new
[5/500] Host: 174177971, status: new
[6/500] Host: 174177971, status: new
[7/500] Host: 174177971, status: new
[8/500] Host: 174177971, status: new
[9/500] Host: 174177971, status: new
[10/500] Host: 174177971, status: new
[11/500] Host: 174177971, status: active
Inlets OSS exit-node summary:
  IP: 167.71.135.125
  Auth-token: q1zbELRejzJPfPOqTYn7WhGUXAgD4Jm1BH51Z2z6RoYxcnRQTsELzfEqpI3M2Nfr

Command:
  export UPSTREAM=http://127.0.0.1:8000
  inlets client --remote "ws://167.71.135.125:8080" \
	--token "q1zbELRejzJPfPOqTYn7WhGUXAgD4Jm1BH51Z2z6RoYxcnRQTsELzfEqpI3M2Nfr" \
	--upstream $UPSTREAM
```
Delete
```
$ inletsctl delete -provider digitalocean --access-token $TOKEN --ip 167.71.135.125
Using provider: digitalocean
Deleting host: 167.71.135.125 from digitalocean
```
Run delete again
```
$ inletsctl delete -provider digitalocean --access-token $TOKEN --ip 167.71.135.125
Using provider: digitalocean
Deleting host: 167.71.135.125 from digitalocean
No host with ip: 167.71.135.125
```

### GCE
Create
```
$ inletsctl create --provider gce --access-token-file ~/gce.json --project-id $PROJECT
Using provider: gce
Requesting host: recursing-sinoussi8 in us-central1-a, from gce
2020/01/04 12:39:35 inlets firewallRule exists
Host: recursing-sinoussi8|us-central1-a|project, status: active
[1/500] Host: recursing-sinoussi8|us-central1-a|project, status:
[2/500] Host: recursing-sinoussi8|us-central1-a|project, status: active
Inlets OSS exit-node summary:
  IP: 35.224.104.93
  Auth-token: 5tUEeif57kTpRvtuPJtMG6u90zOQBqEkJKsH28dLZin2ieJmvOpBLPCLNVKTn4Uj

Command:
  export UPSTREAM=http://127.0.0.1:8000
  inlets client --remote "ws://35.224.104.93:8080" \
	--token "5tUEeif57kTpRvtuPJtMG6u90zOQBqEkJKsH28dLZin2ieJmvOpBLPCLNVKTn4Uj" \
	--upstream $UPSTREAM
```
Delete
```
$inletsctl delete --provider gce --access-token-file ~/gce.json  --ip 35.232.193.171  --project-id $PROJECT
Using provider: gce
Deleting host: 35.224.104.93 from gce
```
Run delete again
```
$inletsctl delete --provider gce --access-token-file ~/gce.json  --ip 35.232.193.171  --project-id $PROJECT
Using provider: gce
Deleting host: 35.224.104.93 from gce
No host with ip: 35.224.104.93
```
### Civo
Create
```
$ inletsctl create --provider civo --access-token $TOKEN
Using provider: civo
Requesting host: optimistic-goldberg3 in , from civo
2020/01/04 12:44:32 Provisioning host with Civo
Instance ID: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91
Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status:
[1/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build_pending
[2/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build_pending
[3/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build_pending
[4/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build_pending
[5/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build_pending
[6/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[7/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[8/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[9/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[10/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[11/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[12/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[13/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[14/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[15/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[16/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[17/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[18/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[19/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[20/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[21/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[22/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: build
[23/500] Host: 1faecc8d-3cf7-492a-b2ef-5bddfd32bf91, status: active
Inlets OSS exit-node summary:
  IP: 185.136.234.55
  Auth-token: j5VW8n7uBNxWI3xeMQH8xFrrYfthCAxCqgmthWUGRCKXlKrqU50KP31KABiwLV7p

Command:
  export UPSTREAM=http://127.0.0.1:8000
  inlets client --remote "ws://185.136.234.55:8080" \
	--token "j5VW8n7uBNxWI3xeMQH8xFrrYfthCAxCqgmthWUGRCKXlKrqU50KP31KABiwLV7p" \
	--upstream $UPSTREAM
```
Delete
```
inletsctl delete --provider civo --access-token $TOKEN --ip 185.136.234.55
Using provider: civo
Deleting host: 185.136.234.55 from civo
```
Run delete again
```
inletsctl delete --provider civo --access-token $TOKEN --ip 185.136.234.55
Using provider: civo
Deleting host: 185.136.234.55 from civo
No host with ip: 185.136.234.55
```

### Scaleway
Create
```
$ inletsctl create --provider scaleway --access-token $TOKEN --secret-key $SECRET_KEY --organisation-id $ORG_ID
```
Delete
```
inletsctl delete --provider scaleway --ip 163.172.166.139 --access-token $TOKEN --secret-key $SECRET_KEY --organisation-id $ORG_ID 
Using provider: scaleway
Deleting host: 163.172.166.139 from scaleway
No instance with ip: 163.172.166.139
```
Run delete again
```
inletsctl delete --provider scaleway --ip 163.172.166.139 --access-token $TOKEN --secret-key $SECRET_KEY --organisation-id $ORG_ID 
Using provider: scaleway
Deleting host: 163.172.166.139 from scaleway
No host with ip: 163.172.166.139
```

### AWS EC2
Create
```
$ inletsctl create  --provider ec2 --access-token-file ~/.aws/inlets-token --secret-key-file ~/.aws/inlets-secret
Using provider: ec2
Requesting host: keen-allen2 in eu-west-1, from ec2
Host: i-0e528be9c01c3fd6a, status: creating
[1/500] Host: i-0e528be9c01c3fd6a, status: creating
[2/500] Host: i-0e528be9c01c3fd6a, status: creating
[3/500] Host: i-0e528be9c01c3fd6a, status: creating
[4/500] Host: i-0e528be9c01c3fd6a, status: creating
[5/500] Host: i-0e528be9c01c3fd6a, status: creating
[6/500] Host: i-0e528be9c01c3fd6a, status: creating
[7/500] Host: i-0e528be9c01c3fd6a, status: creating
[8/500] Host: i-0e528be9c01c3fd6a, status: initialising
[9/500] Host: i-0e528be9c01c3fd6a, status: initialising
[10/500] Host: i-0e528be9c01c3fd6a, status: initialising
[11/500] Host: i-0e528be9c01c3fd6a, status: initialising
[12/500] Host: i-0e528be9c01c3fd6a, status: initialising
[13/500] Host: i-0e528be9c01c3fd6a, status: initialising
[14/500] Host: i-0e528be9c01c3fd6a, status: initialising
[15/500] Host: i-0e528be9c01c3fd6a, status: initialising
[16/500] Host: i-0e528be9c01c3fd6a, status: initialising
[17/500] Host: i-0e528be9c01c3fd6a, status: initialising
[18/500] Host: i-0e528be9c01c3fd6a, status: initialising
[19/500] Host: i-0e528be9c01c3fd6a, status: initialising
[20/500] Host: i-0e528be9c01c3fd6a, status: initialising
[21/500] Host: i-0e528be9c01c3fd6a, status: initialising
[22/500] Host: i-0e528be9c01c3fd6a, status: initialising
[23/500] Host: i-0e528be9c01c3fd6a, status: initialising
[24/500] Host: i-0e528be9c01c3fd6a, status: initialising
[25/500] Host: i-0e528be9c01c3fd6a, status: initialising
[26/500] Host: i-0e528be9c01c3fd6a, status: initialising
[27/500] Host: i-0e528be9c01c3fd6a, status: initialising
[28/500] Host: i-0e528be9c01c3fd6a, status: initialising
[29/500] Host: i-0e528be9c01c3fd6a, status: initialising
[30/500] Host: i-0e528be9c01c3fd6a, status: initialising
[31/500] Host: i-0e528be9c01c3fd6a, status: initialising
[32/500] Host: i-0e528be9c01c3fd6a, status: initialising
[33/500] Host: i-0e528be9c01c3fd6a, status: initialising
[34/500] Host: i-0e528be9c01c3fd6a, status: initialising
[35/500] Host: i-0e528be9c01c3fd6a, status: initialising
[36/500] Host: i-0e528be9c01c3fd6a, status: initialising
[37/500] Host: i-0e528be9c01c3fd6a, status: initialising
[38/500] Host: i-0e528be9c01c3fd6a, status: initialising
[39/500] Host: i-0e528be9c01c3fd6a, status: initialising
[40/500] Host: i-0e528be9c01c3fd6a, status: initialising
[41/500] Host: i-0e528be9c01c3fd6a, status: initialising
[42/500] Host: i-0e528be9c01c3fd6a, status: initialising
[43/500] Host: i-0e528be9c01c3fd6a, status: initialising
[44/500] Host: i-0e528be9c01c3fd6a, status: initialising
[45/500] Host: i-0e528be9c01c3fd6a, status: initialising
[46/500] Host: i-0e528be9c01c3fd6a, status: initialising
[47/500] Host: i-0e528be9c01c3fd6a, status: initialising
[48/500] Host: i-0e528be9c01c3fd6a, status: initialising
[49/500] Host: i-0e528be9c01c3fd6a, status: initialising
[50/500] Host: i-0e528be9c01c3fd6a, status: initialising
[51/500] Host: i-0e528be9c01c3fd6a, status: initialising
[52/500] Host: i-0e528be9c01c3fd6a, status: initialising
[53/500] Host: i-0e528be9c01c3fd6a, status: active
Inlets OSS exit-node summary:
  IP: 54.154.160.107
  Auth-token: 8XpqAVl0J9RXnUqiDpTClvqlYqLAyo3QFqXs0tVbZKzqmx9C4ibM185WTgeMMuvp

Command:
  export UPSTREAM=http://127.0.0.1:8000
  inlets client --remote "ws://54.154.160.107:8080" \
	--token "8XpqAVl0J9RXnUqiDpTClvqlYqLAyo3QFqXs0tVbZKzqmx9C4ibM185WTgeMMuvp" \
	--upstream $UPSTREAM

To Delete:
  inletsctl delete --provider ec2 --id "i-0e528be9c01c3fd6a"
```

Delete
```
$ inletsctl delete --ip 54.154.160.107  --provider ec2 --access-token-file ~/.aws/inlets-token --secret-key-file ~/.aws/inlets-secret
Using provider: ec2
Deleting host: 54.154.160.107 from ec2
```
Run delete again
```
$ delete --ip 54.154.160.107  --provider ec2 --access-token-file ~/.aws/inlets-token --secret-key-file ~/.aws/inlets-secret
Using provider: ec2
Deleting host: 54.154.160.107 from ec2
no host with ip: 54.154.160.107
```


## How are existing users impacted? What migration steps/scripts do we need?
This functionality will only work on exit nodes created with a version that contains this pull request as it tags or labels the exit nodes.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
