### PR TITLE
Add command to download inlets(pro)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /inletsctl
 /bin/**
+.idea/

--- a/README.md
+++ b/README.md
@@ -146,6 +146,25 @@ inletsctl kfwd --if 192.168.0.14 --from openfaas-figlet:8080
 
 Then access the service via `http://127.0.0.1:8080`.
 
+
+## Downloading inlets or inlets-pro
+
+The `inletsctl download` command can be used to download the inlets or inltets-pro binaries from github
+
+Example usage:
+
+```sh
+# Download the latest inlets binary
+inletsctl download
+
+#Download the latest inlets-pro binary
+inletsctl download --pro
+
+# Download a specific version of inlets/inlets-pro
+inletsctl download --version 2.6.2
+```
+
+
 ## Contributing
 
 ### Add another cloud provisioner

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -1,0 +1,214 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"runtime"
+	"strings"
+)
+
+var (
+	inletsPro       bool
+	downloadVersion string
+	destination     string
+)
+
+func init() {
+	inletsCmd.AddCommand(downloadCmd)
+
+	downloadCmd.Flags().BoolVar(&inletsPro, "pro", false, "Download inlets pro")
+	downloadCmd.Flags().StringVar(&downloadVersion, "version", "", "specific version to download")
+	downloadCmd.Flags().StringVar(&destination, "download-to", "/usr/local/bin", "location to download to (Default: /usr/local/bin)")
+}
+
+var downloadCmd = &cobra.Command{
+	Use:   "download",
+	Short: "Download the inlets or inlets pro binary",
+	Long:  `Download the inlets or inlets pro binary`,
+	Example: `  inletsctl download 
+`,
+	RunE:          downloadInlets,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func downloadInlets(_ *cobra.Command, _ []string) error {
+
+	var versionUrl, downloadUrl, binaryName string
+
+	if inletsPro {
+		versionUrl = "https://github.com/inlets/inlets-pro-pkg/releases/latest"
+		downloadUrl = "https://github.com/inlets/inlets-pro-pkg/releases/download/"
+		binaryName = "inlets-pro"
+	} else {
+		versionUrl = "https://github.com/inlets/inlets/releases/latest"
+		downloadUrl = "https://github.com/inlets/inlets/releases/download/"
+		binaryName = "inlets"
+	}
+
+	osVal := runtime.GOOS
+	arch := runtime.GOARCH
+
+	extension := ""
+
+	if osVal == "windows" {
+		extension = ".exe"
+	}
+
+	if arch == "arm" {
+		arch = "armhf"
+	}
+
+	if arch == "amd64" {
+		arch = ""
+	} else {
+		arch = "-" + arch
+	}
+
+	if len(downloadVersion) == 0 {
+		var err error
+		downloadVersion, err = findRelease(versionUrl)
+		if err != nil {
+			return err
+		}
+	}
+
+	url := downloadUrl + downloadVersion + "/" + binaryName + arch + extension
+	fmt.Printf("Starting download of %s %s, this could take a few moments.\n", binaryName, downloadVersion)
+	output, err := downloadBinary(http.DefaultClient, url, binaryName)
+
+	if err != nil {
+		return err
+	}
+
+	var permissionErr bool
+	err, permissionErr = moveFile(output, path.Join(destination, binaryName))
+	if err != nil && !permissionErr {
+		return err
+	}
+
+	if permissionErr {
+		installLocation := path.Join(destination, binaryName)
+		fmt.Printf(`==============================================================
+    The command was run as a user who is unable to write
+    to %s. To complete the installation run as a 
+    user that can write to this location.
+==============================================================
+
+Alternativly you can move the file using these commands
+  curl -SLsf %s > /tmp/%s
+  chmod a+x %s
+  %s version
+  sudo mv %s  %s
+`, destination, url, binaryName, output, output, output, installLocation)
+		if err := os.Remove(output); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	fmt.Printf(`Download completed, make sure that %s is on your path. 
+  %s version
+`, destination, binaryName)
+
+	return nil
+}
+
+func findRelease(url string) (string, error) {
+
+	client := http.Client{}
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	req, err := http.NewRequest(http.MethodHead, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+	if res.StatusCode != 302 {
+		return "", fmt.Errorf("incorrect status code: %d", res.StatusCode)
+	}
+
+	loc := res.Header.Get("Location")
+	if len(loc) == 0 {
+		return "", fmt.Errorf("unable to determine release of inlets")
+	}
+	version := loc[strings.LastIndex(loc, "/")+1:]
+	return version, nil
+}
+
+func downloadBinary(client *http.Client, url, name string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	tempDir := os.TempDir()
+	outputPath := path.Join(tempDir, name)
+	if res.Body != nil {
+		defer res.Body.Close()
+		res, _ := ioutil.ReadAll(res.Body)
+
+		err := ioutil.WriteFile(outputPath, res, 0777)
+		if err != nil {
+			return "", err
+		}
+		return outputPath, nil
+	}
+	return "", fmt.Errorf("error downloading %s", url)
+}
+func moveFile(source, destination string) (error, bool) {
+	src, err := os.Open(source)
+	if err != nil {
+		return err, false
+	}
+	defer src.Close()
+	fi, err := src.Stat()
+	if err != nil {
+		return err, false
+	}
+	flag := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
+	perm := fi.Mode() & os.ModePerm
+
+	dst, err := os.OpenFile(destination, flag, perm)
+	if err != nil {
+		return err, true
+	}
+	defer dst.Close()
+	_, err = io.Copy(dst, src)
+	if err != nil {
+		dst.Close()
+		os.Remove(destination)
+		return err, false
+	}
+	err = dst.Close()
+	if err != nil {
+		return err, false
+	}
+	err = src.Close()
+	if err != nil {
+		return err, false
+	}
+	err = os.Remove(source)
+	if err != nil {
+		return err, false
+	}
+	return nil, false
+}


### PR DESCRIPTION
## Description

Added a command to download inlets, and a flag for making
that download intlets-pro. We work out what arch we are
working on, and the os. We then get latest version, or
use the version supplied in --download-version to get the
correct binary from github.

This has been tested by running the commands on Linux arm64
and armhf (Rpi3)

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

Fixes #12 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Help command: 
```
heyal@heyal-xps:~/go/src/github.com/inlets/inletsctl$ ./inletsctl download --help
heyal@heyal-xps:~/go/src/github.com/inlets/inletsctl$ ./inletsctl download --help
Download the inlets or inlets pro binary

Usage:
  inletsctl download [flags]

Examples:
  inletsctl download 


Flags:
  -h, --help             help for download
      --pro              Download inlets pro
      --version string   specific version to download

```

Running for the non-pro version
```
heyal@heyal-xps:~/go/src/github.com/inlets/inletsctl$ ./inletsctl download 
Starting download of inlets 2.6.3, this could take a few moments.
Download completed, please run:
  chmod +x /tmp/inlets
  /tmp/inlets version
  sudo install /tmp/inlets /usr/local/bin/
heyal@heyal-xps:~/go/src/github.com/inlets/inletsctl$ chmod +x /tmp/inlets
heyal@heyal-xps:~/go/src/github.com/inlets/inletsctl$ /tmp/inlets version
 _       _      _            _
(_)_ __ | | ___| |_ ___   __| | _____   __
| | '_ \| |/ _ \ __/ __| / _` |/ _ \ \ / /
| | | | | |  __/ |_\__ \| (_| |  __/\ V /
|_|_| |_|_|\___|\__|___(_)__,_|\___| \_/

Version: 2.6.3
Git Commit: c2033ecaaef9381d975a3fcadb86011056865fb9
```

Downloading a specific version:

```
heyal@heyal-xps:~/go/src/github.com/inlets/inletsctl$ ./inletsctl download --version 2.6.2
Starting download of inlets 2.6.2, this could take a few moments.
Download completed, please run:
  chmod +x /tmp/inlets
  /tmp/inlets version
  sudo install /tmp/inlets /usr/local/bin/
heyal@heyal-xps:~/go/src/github.com/inlets/inletsctl$ chmod +x /tmp/inlets
heyal@heyal-xps:~/go/src/github.com/inlets/inletsctl$ /tmp/inlets version
 _       _      _            _
(_)_ __ | | ___| |_ ___   __| | _____   __
| | '_ \| |/ _ \ __/ __| / _` |/ _ \ \ / /
| | | | | |  __/ |_\__ \| (_| |  __/\ V /
|_|_| |_|_|\___|\__|___(_)__,_|\___| \_/

Version: 2.6.2
Git Commit: 8d99e082593c9441af66833211bf8c6ed4a74394
```

Downloading inlets-pro
```
heyal@heyal-xps:~/go/src/github.com/inlets/inletsctl$ ./inletsctl download --pro
Starting download of inlets-pro 0.4.2, this could take a few moments.
Download completed, please run:
  chmod +x /tmp/inlets-pro
  /tmp/inlets-pro version
  sudo install /tmp/inlets-pro /usr/local/bin/
```

## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests