### PR TITLE
WIP: add defaults and move functions to provision package

### DIFF
--- a/cmd/kfwd.go
+++ b/cmd/kfwd.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/inlets/inletsctl/pkg/provision"
 	"io/ioutil"
 	"log"
 	"os"
@@ -73,7 +74,7 @@ func runKfwd(cmd *cobra.Command, _ []string) error {
 
 	fmt.Println(upstream, "=", port)
 
-	inletsToken, passwordErr := generateAuth()
+	inletsToken, passwordErr := provision.GenerateAuth()
 	if passwordErr != nil {
 		return passwordErr
 	}

--- a/pkg/provision/civo.go
+++ b/pkg/provision/civo.go
@@ -108,10 +108,6 @@ func (p *CivoProvisioner) Provision(host BasicHost) (*ProvisionedHost, error) {
 
 	log.Printf("Provisioning host with Civo\n")
 
-	if host.Region == "" {
-		host.Region = "lon1"
-	}
-
 	res, err := provisionCivoInstance(host, p.APIKey)
 
 	if err != nil {

--- a/pkg/provision/digitalocean.go
+++ b/pkg/provision/digitalocean.go
@@ -64,10 +64,6 @@ func (p *DigitalOceanProvisioner) Provision(host BasicHost) (*ProvisionedHost, e
 
 	log.Printf("Provisioning host with DigitalOcean\n")
 
-	if host.Region == "" {
-		host.Region = "lon1"
-	}
-
 	createReq := &godo.DropletCreateRequest{
 		Name:   host.Name,
 		Region: host.Region,

--- a/pkg/provision/packet.go
+++ b/pkg/provision/packet.go
@@ -48,15 +48,12 @@ func (p *PacketProvisioner) Delete(id string) error {
 }
 
 func (p *PacketProvisioner) Provision(host BasicHost) (*ProvisionedHost, error) {
-	if host.Region == "" {
-		host.Region = "ams1"
-	}
 
 	createReq := &packngo.DeviceCreateRequest{
 		Plan:         host.Plan,
 		Facility:     []string{host.Region},
 		Hostname:     host.Name,
-		ProjectID:    host.Additional["project_id"],
+		ProjectID:    host.ProjectID,
 		SpotInstance: false,
 		OS:           host.OS,
 		BillingCycle: "hourly",

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -1,5 +1,10 @@
 package provision
 
+import (
+	"fmt"
+	"github.com/sethvargo/go-password/password"
+)
+
 type Provisioner interface {
 	Provision(BasicHost) (*ProvisionedHost, error)
 	Status(id string) (*ProvisionedHost, error)
@@ -8,6 +13,80 @@ type Provisioner interface {
 
 const ActiveStatus = "active"
 
+const DigitaloceanProvider = "digitalocean"
+const ScalewayProvider = "scaleway"
+const GCEProvider = "gce"
+const PacketProvider = "packet"
+const CivoProvider = "civo"
+const EC2Provider = "ec2"
+
+const ControlPort = "8080"
+
+type ProvisionerDefaults struct {
+	OS     string
+	Plan   string
+	Region string
+	Zone   string
+}
+
+var Defaults = map[string]ProvisionerDefaults{
+	DigitaloceanProvider: {
+		OS:   "ubuntu-16-04-x64",
+		Plan: "512mb",
+		Region: "lon1",
+	},
+	PacketProvider: {
+		OS:     "ubuntu_16_04",
+		Plan:   "t1.small.x86",
+		Region: "ams1",
+	},
+	ScalewayProvider: {
+		OS:     "ubuntu-bionic",
+		Plan:   "DEV1-S",
+		Region: "fr-par-1",
+	},
+	CivoProvider: {
+		OS:   "811a8dfb-8202-49ad-b1ef-1e6320b20497",
+		Plan: "g2.small",
+		Region: "lon1",
+	},
+	GCEProvider: {
+		OS:   "projects/debian-cloud/global/images/debian-9-stretch-v20191121",
+		Plan: "f1-micro",
+		Zone: "us-central1-a",
+	},
+	EC2Provider: {
+		OS:     "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20191114",
+		Plan:   "t3.nano",
+		Region: "eu-west-1",
+	},
+}
+
+type ProvisionerRequest struct {
+	Provider       string
+	AccessToken    string
+	SecretKey      string
+	OrganisationID string
+	Region         string
+}
+
+func NewProvisioner(request ProvisionerRequest) (Provisioner, error) {
+	if request.Provider == DigitaloceanProvider {
+		return NewDigitalOceanProvisioner(request.AccessToken)
+	} else if request.Provider == PacketProvider {
+		return NewPacketProvisioner(request.AccessToken)
+	} else if request.Provider == CivoProvider {
+		return NewCivoProvisioner(request.AccessToken)
+	} else if request.Provider == ScalewayProvider {
+		return NewScalewayProvisioner(request.AccessToken, request.SecretKey, request.OrganisationID, request.Region)
+	} else if request.Provider == GCEProvider {
+		return NewGCEProvisioner(request.AccessToken)
+	} else if request.Provider == EC2Provider {
+		return NewEC2Provisioner(request.AccessToken, request.SecretKey, request.Region)
+	}
+	return nil, fmt.Errorf("no provisioner for provider: %s", request.Provider)
+}
+
 type ProvisionedHost struct {
 	IP     string
 	ID     string
@@ -15,10 +94,79 @@ type ProvisionedHost struct {
 }
 
 type BasicHost struct {
-	Region     string
-	Plan       string
-	OS         string
-	Name       string
-	UserData   string
-	Additional map[string]string
+	Region    string
+	Plan      string
+	OS        string
+	Name      string
+	UserData  string
+	ProjectID string
+	Zone      string
+}
+
+func NewBasicHost(provider, name, region, projectID, zone, userData string) (*BasicHost, error) {
+	if _, ok := Defaults[provider]; !ok {
+		return nil, fmt.Errorf("no provisioner for provider: %q", provider)
+	}
+	host := &BasicHost{
+		Name:      name,
+		OS:        Defaults[provider].OS,
+		Plan:      Defaults[provider].Plan,
+		UserData:  userData,
+		ProjectID: projectID,
+	}
+	if region == "" && len(Defaults[provider].Region) != 0 {
+		host.Region = Defaults[provider].Region
+	} else {
+		host.Region = region
+	}
+	if zone == "" && len(Defaults[provider].Zone) != 0 {
+		host.Zone = Defaults[provider].Zone
+	} else {
+		host.Zone = zone
+	}
+	return host, nil
+}
+
+func GenerateAuth() (string, error) {
+	pwdRes, pwdErr := password.Generate(64, 10, 0, false, true)
+	return pwdRes, pwdErr
+}
+
+type UserDataRequest struct {
+	AuthToken string
+	InletsControlPort string
+	RemoteTCP string
+}
+
+func MakeUserdata(request UserDataRequest) string {
+	if len(request.RemoteTCP) == 0 {
+		return `#!/bin/bash
+export AUTHTOKEN="` + request.AuthToken + `"
+export CONTROLPORT="` + request.InletsControlPort + `"
+curl -sLS https://get.inlets.dev | sh
+
+curl -sLO https://raw.githubusercontent.com/inlets/inlets/master/hack/inlets-operator.service  && \
+	mv inlets-operator.service /etc/systemd/system/inlets.service && \
+	echo "AUTHTOKEN=$AUTHTOKEN" > /etc/default/inlets && \
+	echo "CONTROLPORT=$CONTROLPORT" >> /etc/default/inlets && \
+	systemctl start inlets && \
+	systemctl enable inlets`
+	}
+
+	return `#!/bin/bash
+	export AUTHTOKEN="` + request.AuthToken + `"
+	export REMOTETCP="` + request.RemoteTCP + `"
+	export IP=$(curl -sfSL https://ifconfig.co)
+
+	curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.0/inlets-pro-linux > inlets-pro-linux && \
+	chmod +x ./inlets-pro-linux  && \
+	mv ./inlets-pro-linux /usr/local/bin/inlets-pro
+
+	curl -sLO https://raw.githubusercontent.com/inlets/inlets/master/hack/inlets-pro.service  && \
+		mv inlets-pro.service /etc/systemd/system/inlets-pro.service && \
+		echo "AUTHTOKEN=$AUTHTOKEN" >> /etc/default/inlets-pro && \
+		echo "REMOTETCP=$REMOTETCP" >> /etc/default/inlets-pro && \
+		echo "IP=$IP" >> /etc/default/inlets-pro && \
+		systemctl start inlets-pro && \
+		systemctl enable inlets-pro`
 }

--- a/pkg/provision/scaleway.go
+++ b/pkg/provision/scaleway.go
@@ -17,7 +17,7 @@ type ScalewayProvisioner struct {
 // NewScalewayProvisioner with an accessKey and secretKey
 func NewScalewayProvisioner(accessKey, secretKey, organizationID, region string) (*ScalewayProvisioner, error) {
 	if region == "" {
-		region = "fr-par-1"
+		region = Defaults[ScalewayProvider].Region
 	}
 
 	zone, err := scw.ParseZone(region)


### PR DESCRIPTION
## Description

As suggested in #17 I have created this pull request to demonstrate what I am proposing. This ended up being a little more than I was originally suggesting as I have also moved a couple of functions into provision as well. After looking at the code in the operator project I think we can remove some of the duplication by doing this or some of it.

## How Has This Been Tested?
I have tested it, but this if for demonstration purposes for the moment and will require a little more work

## How are existing users impacted? What migration steps/scripts do we need?
This would only require changes if downstream users wanted to use the defaults instead of setting them. 

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests
