### PR TITLE
Update an output to use env var not hard coded value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /inletsctl
 /bin/**
+.idea/

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -201,9 +201,12 @@ Command:
   inlets-pro client --connect "wss://%s:%d/connect" \
 	--token "%s" \
 	--license "$LICENSE" \
-	--tcp-ports 8000
+	--tcp-ports $TCP_PORTS
+
+To Delete:
+	  inletsctl delete --provider %s --id "%s"
 `,
-				hostStatus.IP, inletsToken, hostStatus.IP, proPort, inletsToken)
+				hostStatus.IP, inletsToken, hostStatus.IP, proPort, inletsToken, provider, hostStatus.ID)
 
 			return nil
 		}


### PR DESCRIPTION
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

## Description
The example output when using `--remote-tcp` to create an inlets-pro exit node was setting and env var and not using it. 


Fixes #24 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
Command:
  export TCP_PORTS="8000"
  export LICENSE=""
  inlets-pro client --connect "wss://167.71.129.178:8123/connect" \
        --token "my_secret_token" \
        --license "$LICENSE" \
        --tcp-ports $TCP_PORTS
To Delete:
          inletsctl delete --provider digitalocean --id "175013350"
```

then i tested this by setting up the client and then SSHing to the local RPi through the exit node

```heyal@heyal-xps:~/code/waterdrips.github.io$ ssh -p 2222 pi@167.71.129.178
The authenticity of host '[167.71.129.178]:2222 ([167.71.129.178]:2222)' can't be established.
ECDSA key fingerprint is SHA256:Oc4wNrUObnzGqjVjpXLPd48k0R8EuFi1Bu4ycXXjHCc.
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '[167.71.129.178]:2222' (ECDSA) to the list of known hosts.
Linux raspberrypi 4.19.75-v7+ #1270 SMP Tue Sep 24 18:45:11 BST 2019 armv7l

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Last login: Fri Jan 10 08:33:52 2020 from 192.168.0.69

```
I then deleted the node using the newly added output: 

```
heyal@heyal-xps:~/go/src/github.com/inlets/inletsctl$ inletsctl delete --provider digitalocean --id "175013350" -f ~/do-token 
Using provider: digitalocean
Deleting host: 175013350 from digitalocean

```
## How are existing users impacted? What migration steps/scripts do we need?
Added extra clarification to output. no impact to existing versions.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
