### PR TITLE
Fix: add the region flag to the delete command

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -12,6 +13,7 @@ import (
 func init() {
 	inletsCmd.AddCommand(deleteCmd)
 	deleteCmd.Flags().StringP("provider", "p", "digitalocean", "The cloud provider - digitalocean, gce, ec2, packet, scaleway, or civo")
+	deleteCmd.Flags().StringP("region", "r", "lon1", "The region for your cloud provider")
 
 	deleteCmd.Flags().StringP("inlets-token", "t", "", "The inlets auth token for your exit node")
 	deleteCmd.Flags().StringP("access-token", "a", "", "The access token for your cloud")


### PR DESCRIPTION
## Description

Add support for the `--region` flag when deleting an exit node.  

## How Has This Been Tested?

Before:
```
$ go run main.go delete  --provider ec2 --access-token=ACCES_TOKEN --secret-key=SECRET --region=eu-west-3 --id INSTANCE_ID
unknown flag: --region
exit status 1
```

After
```
$ go run main.go delete  --provider ec2 --access-token=ACCES_TOKEN --secret-key=SECRET --region=eu-west-3 --id INSTANCE_ID
Using provider: ec2
Deleting host: INSTANCE_ID from ec2
```

## How are existing users impacted? What migration steps/scripts do we need?

Nothing.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
