### PR TITLE
Fix issue 32 for download on MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: go
 
 go:
-- 1.12.x
+- 1.13.x
 
 script:
 - make dist

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Inlets
+Copyright (c) 2020 Inlets Author(s)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import "testing"
+
+func Test_BuildFilename_Linux_amd64(t *testing.T) {
+	arch, ext := buildFilename("amd64", "linux")
+	want := ""
+
+	if want != arch+ext {
+		t.Errorf("want: %s, but got: %s", want, arch+ext)
+	}
+}
+
+func Test_BuildFilename_Windows_amd64(t *testing.T) {
+	arch, ext := buildFilename("amd64", "windows")
+	want := ".exe"
+
+	if want != arch+ext {
+		t.Errorf("want: %s, but got: %s", want, arch+ext)
+	}
+}
+
+func Test_BuildFilename_Linux_arm64(t *testing.T) {
+	arch, ext := buildFilename("arm64", "linux")
+	want := "-arm64"
+
+	if want != arch+ext {
+		t.Errorf("want: %s, but got: %s", want, arch+ext)
+	}
+}
+
+func Test_BuildFilename_Linux_armhf(t *testing.T) {
+	arch, ext := buildFilename("armhf", "linux")
+	want := "-armhf"
+
+	if want != arch+ext {
+		t.Errorf("want: %s, but got: %s", want, arch+ext)
+	}
+}
+
+func Test_BuildFilename_Darwin_amd64(t *testing.T) {
+	arch, ext := buildFilename("amd64", "darwin")
+	want := "-darwin"
+
+	if want != arch+ext {
+		t.Errorf("want: %s, but got: %s", want, arch+ext)
+	}
+}

--- a/cmd/inletsctl.go
+++ b/cmd/inletsctl.go
@@ -24,6 +24,7 @@ const WelcomeMessage = "Welcome to inletsctl! Find out more at https://github.co
 
 func init() {
 	inletsCmd.AddCommand(versionCmd)
+	inletsCmd.AddCommand(makeUpdate())
 }
 
 // inletsCmd represents the base command when called without any sub commands.

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func makeUpdate() *cobra.Command {
+	var command = &cobra.Command{
+		Use:          "update",
+		Short:        "Print update instructions",
+		Example:      `  inletsctl update`,
+		SilenceUsage: false,
+	}
+	command.Run = func(cmd *cobra.Command, args []string) {
+		fmt.Println(updateStr)
+	}
+	return command
+}
+
+const updateStr = `You can update inletsctl with the following:
+
+# For Linux/MacOS:
+curl -SLfs https://inletsctl.inlets.dev | sudo sh
+
+# For Windows (using Git Bash)
+curl -SLfs https://inletsctl.inlets.dev | sh
+
+# Or download from GitHub: https://github.com/inlets/inletsctl/releases
+
+Thanks for using inletsctl!`


### PR DESCRIPTION
Added unit tests to make sure the binary name is created as
per the releases page. Tested on MacOS and with new unit tests
to show no regression for Linux etc.

Fixes: #32

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>
