### PR TITLE
Compresses the binaries with gzip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,34 @@
 sudo: required
 language: go
-
 go:
 - 1.13.x
-
 script:
 - make dist
-
 before_deploy:
 - "./ci/hashgen.sh"
-
 deploy:
-  provider: releases
   api_key:
     secure: aYgBmrFjqAzOBWncNQ2EKKFZJwOD2+l+a7Lll8+DVJkNyvLdzliI8iD4ro5KLEIwJjlghwM/Xy78O5oMlTPGoBf6IwbFE4nxKr0wlwFonSym5XCW2W7diGwxNvJUvBqY3wHjV13UpFNJVOqKbcaAVC+oGP6Wt4vNttroUaikpokwTfDXneksg5YIIemKkNXAvvWyRHrdOUgn8U8qLnaJ5gdpdcQOACsVXoI43ogsX49nSqXVIaBqt1Ndz+53Dsu7nSUwuwg0CnTYT05sU83RUhzRckvoE/l3mmd/FQBmVyDTfTwjrVwQLaKv2ldqlDmasV1qQ32bsEAfnGswbEZcJ0Qpx6VasAtDk69OW0RPyHs/VMw9BHVgoQyDaO2KGTKBJBBsewaIcJPBnWcDoGsv8oV/s/6tagqT+20zobGLqJfu3JxPlG7m+mC17NW8Fe9UslexyP9R1PgJfghGqQisDIrid9KixqfMpfTAqLykVGR3ra5NctKJEvpM2lyjLsxKxgzRAeIcd/i6Rt/eQX7lQAFQuP+Gq/hwxffFFUvUJPaBg5xk69S5QF6OrVof/LJjReE39u5z+q3O4f1auyZXSlE3ZNTWJEZ2DCuD5fLQm1b2O8sTAuK2HXnPr2gLvjUTO5QaRlQiVwxeYNcaMol42VFZ+XpBU+PQOuhSUmpqhOk=
+  provider: releases
   file:
-    - ./bin/inletsctl
-    - ./bin/inletsctl-darwin
-    - ./bin/inletsctl-armhf
-    - ./bin/inletsctl-arm64
-    - ./bin/inletsctl.exe
-    - ./bin/inletsctl.sha256
-    - ./bin/inletsctl-darwin.sha256
-    - ./bin/inletsctl-armhf.sha256
-    - ./bin/inletsctl-arm64.sha256
-    - ./bin/inletsctl.exe.sha256
+  - "./bin/inletsctl.tgz"
+  - "./bin/inletsctl.sha256"
+  - "./bin/inletsctl.tgz.sha256"
+  - "./bin/inletsctl-darwin.tgz"
+  - "./bin/inletsctl-darwin.sha256"
+  - "./bin/inletsctl-darwin.tgz.sha256"
+  - "./bin/inletsctl-armhf.tgz"
+  - "./bin/inletsctl-armhf.sha256"
+  - "./bin/inletsctl-armhf.tgz.sha256"
+  - "./bin/inletsctl-arm64.tgz"
+  - "./bin/inletsctl-arm64.sha256"
+  - "./bin/inletsctl-arm64.tgz.sha256"
+  - "./bin/inletsctl.exe.tgz"
+  - "./bin/inletsctl.exe.sha256"
+  - "./bin/inletsctl.exe.tgz.sha256"
   skip_cleanup: true
   on:
     tags: true
-
-env: GO111MODULE=on
+env:
+  matrix:
+  - GO111MODULE=on

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ dist:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/inletsctl-armhf
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/inletsctl-arm64
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/inletsctl.exe
+
+	echo "Compressing the compiled artifacts"
+	find bin -name "inletsctl*" -exec tar -cvzf {}.tgz {} \;


### PR DESCRIPTION
Changes in Makefile, travis.yml, and get.sh makes sure
that the binary sizes are drastically reduced for downloads.
Closes: #30

Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

## Description
The PR when merged will enable to reduce the download times on the inletsctl binary by compressing the binaries for each platform with gzip compression format

## How Has This Been Tested?
Tested on Linux (amd64)
<img width="963" alt="Screenshot 2020-02-20 at 12 29 30 PM" src="https://user-images.githubusercontent.com/25264581/74909011-5a889600-53dd-11ea-80ad-454278cb20c7.png">
Tested on MacOS (amd64)
<img width="1245" alt="Screenshot 2020-02-20 at 12 32 37 PM" src="https://user-images.githubusercontent.com/25264581/74909029-65dbc180-53dd-11ea-9ee4-d8c97fe693a1.png">

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?
<img width="392" alt="Screenshot 2020-01-24 at 11 27 35 AM" src="https://user-images.githubusercontent.com/25264581/73047716-b0305800-3e9c-11ea-8e32-71fca97957f9.png">


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
