### PR TITLE
Fix gce delete command

### DIFF
--- a/pkg/provision/gce.go
+++ b/pkg/provision/gce.go
@@ -164,10 +164,10 @@ func (p *GCEProvisioner) createInletsFirewallRule(projectID string, firewallRule
 
 // Delete deletes the GCE exit node
 func (p *GCEProvisioner) Delete(request HostDeleteRequest) error {
-	var instanceName string
+	var instanceName, projectID, zone string
 	var err error
 	if len(request.ID) > 0 {
-		instanceName, _, _, err = getGCEFieldsFromID(request.ID)
+		instanceName, zone, projectID, err = getGCEFieldsFromID(request.ID)
 		if err != nil {
 			return err
 		}
@@ -180,8 +180,10 @@ func (p *GCEProvisioner) Delete(request HostDeleteRequest) error {
 		if err != nil {
 			return err
 		}
+		projectID = request.ProjectID
+		zone = request.Zone
 	}
-	_, err = p.gceProvisioner.Instances.Delete(request.ProjectID, request.Zone, instanceName).Do()
+	_, err = p.gceProvisioner.Instances.Delete(projectID, zone, instanceName).Do()
 	if err != nil {
 		return fmt.Errorf("could not delete the GCE instance: %v", err)
 	}


### PR DESCRIPTION
## Description
Fix an issue introduced when add the delete by ip functionality in the gce
provisioner. This will closes #31 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

create
```
❯ bin/inletsctl-darwin create --provider gce --access-token-file ~/.inletsctl/inlets-263813-93cf14c8dc5f.json --project-id inlets-263813
Using provider: gce
Requesting host: eloquent-lichterman0 in us-central1-a, from gce
2020/01/23 21:04:21 inlets firewallRule exists
Host: eloquent-lichterman0|us-central1-a|inlets-263813, status: active
[1/500] Host: eloquent-lichterman0|us-central1-a|inlets-263813, status:
[2/500] Host: eloquent-lichterman0|us-central1-a|inlets-263813, status:
[3/500] Host: eloquent-lichterman0|us-central1-a|inlets-263813, status:
[4/500] Host: eloquent-lichterman0|us-central1-a|inlets-263813, status:
[5/500] Host: eloquent-lichterman0|us-central1-a|inlets-263813, status: active
Inlets OSS exit-node summary:
  IP: 35.232.83.17
```

delete by id
```
❯ bin/inletsctl-darwin delete --id "eloquent-lichterman0|us-central1-a|inlets-263813"  --provider gce --access-token-file ~/.inletsctl/inlets-263813-93cf14c8dc5f.json
Using provider: gce
Deleting host: eloquent-lichterman0|us-central1-a|inlets-263813 from gce
```
## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
