### PR TITLE
Add Env Var support for access-token flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ Completed:
 * [x] Provisioner: AWS EC2
 * [x] `inletsctl delete` command
 * [x] Add poll interval `--poll 5s` for use with Civo that applies rate-limiting
+* [x] Install `inlets/inlets-pro` via `inletsctl download` [#12](https://github.com/inlets/inletsctl/issues/12)
 
 Pending:
 
 * [ ] Enable `inletsctl delete` via `--ip` vs. instance ID [#2](https://github.com/inlets/inletsctl/issues/2)
-* [ ] Install `inlets/inlets-pro` via `inletsctl download` [#12](https://github.com/inlets/inletsctl/issues/12)
 * [ ] Enable `inlets-pro` and TCP with `inletsctl kfwd` [#13](https://github.com/inlets/inletsctl/issues/13)
 * [ ] Generate systemd unit files for tunnels
 
@@ -190,6 +190,32 @@ inletsctl download --pro
 
 # Download a specific version of inlets/inlets-pro
 inletsctl download --version 2.6.2
+```
+
+## Configuration using environment variables
+
+You may want to set an environment variable that points at your `access-token-file` or `secret-key-file`
+
+Inlets will look for the following:
+
+```sh
+# For providers that use --access-token-file
+INLETS_ACCESS_TOKEN
+
+
+# For providers that use --secret-key-file
+INLETS_SECRET_KEY
+
+```
+With the correct one of these set you wont need to add the flag on every command execution. 
+
+You can set the following syntax in your `bashrc` (or equivalent for your shell)
+
+```sh
+export INLETS_ACCESS_TOKEN=$(cat my-token.txt)
+
+# or set the INLETS_SECRET_KEY for those providors that use this
+export INLETS_SECRET_KEY=$(cat my-token.txt)
 ```
 
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -6,15 +6,16 @@ package cmd
 import (
 	"encoding/base64"
 	"fmt"
+	"github.com/inlets/inletsctl/pkg/env"
 	"strconv"
 	"strings"
 	"time"
 
-	names "github.com/inlets/inletsctl/pkg/names"
-	provision "github.com/inlets/inletsctl/pkg/provision"
+	"github.com/inlets/inletsctl/pkg/names"
+	"github.com/inlets/inletsctl/pkg/provision"
 
 	"github.com/pkg/errors"
-	password "github.com/sethvargo/go-password/password"
+	"github.com/sethvargo/go-password/password"
 	"github.com/spf13/cobra"
 )
 
@@ -90,7 +91,11 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 		poll = pollOverride
 	}
 
-	accessToken, err := getFileOrString(cmd.Flags(), "access-token-file", "access-token", true)
+	accessToken, err := env.GetRequiredFileOrString(cmd.Flags(),
+		"access-token-file",
+		"access-token",
+		"INLETS_ACCESS_TOKEN",
+	)
 	if err != nil {
 		return err
 	}
@@ -122,7 +127,11 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 	if provider == "scaleway" || provider == "ec2" {
 
 		var secretKeyErr error
-		secretKey, secretKeyErr = getFileOrString(cmd.Flags(), "secret-key-file", "secret-key", true)
+		secretKey, secretKeyErr = env.GetRequiredFileOrString(cmd.Flags(),
+			"secret-key-file",
+			"secret-key",
+			"INLETS_SECRET_KEY",
+		)
 		if secretKeyErr != nil {
 			return secretKeyErr
 		}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/inlets/inletsctl/pkg/env"
 
 	"github.com/inlets/inletsctl/pkg/provision"
 	"github.com/pkg/errors"
@@ -67,7 +68,11 @@ func runDelete(cmd *cobra.Command, _ []string) error {
 		region = "eu-west-1"
 	}
 
-	accessToken, err := getFileOrString(cmd.Flags(), "access-token-file", "access-token", true)
+	accessToken, err := env.GetRequiredFileOrString(cmd.Flags(),
+		"access-token-file",
+		"access-token",
+		"INLETS_ACCESS_TOKEN",
+	)
 	if err != nil {
 		return err
 	}
@@ -76,7 +81,11 @@ func runDelete(cmd *cobra.Command, _ []string) error {
 	var organisationID string
 	if provider == "scaleway" || provider == "ec2" {
 		var secretKeyErr error
-		secretKey, secretKeyErr = getFileOrString(cmd.Flags(), "secret-key-file", "secret-key", true)
+		secretKey, secretKeyErr = env.GetRequiredFileOrString(cmd.Flags(),
+			"secret-key-file",
+			"secret-key",
+			"INLETS_SECRET_KEY",
+		)
 		if secretKeyErr != nil {
 			return secretKeyErr
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,16 +3,12 @@ module github.com/inlets/inletsctl
 go 1.13
 
 require (
-	cloud.google.com/go v0.49.0
+	cloud.google.com/go v0.49.0 // indirect
 	github.com/alexellis/go-execute v0.0.0-20191029181357-d17947259f74
 	github.com/aws/aws-sdk-go v1.26.8
 	github.com/digitalocean/godo v1.27.0
-	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9
-	github.com/golang/protobuf v1.3.2
-	github.com/google/go-querystring v1.0.0
+	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
 	github.com/google/uuid v1.1.1
-	github.com/inconshreveable/mousetrap v1.0.0
-	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 	github.com/morikuni/aec v1.0.0
 	github.com/packethost/packngo v0.2.0
 	github.com/pkg/errors v0.8.1
@@ -20,14 +16,13 @@ require (
 	github.com/sethvargo/go-password v0.1.3
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
-	go.opencensus.io v0.22.2
-	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933
+	go.opencensus.io v0.22.2 // indirect
+	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933 // indirect
 	golang.org/x/oauth2 v0.0.0-20191122200657-5d9234df094c
-	golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9
-	golang.org/x/text v0.3.2
+	golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9 // indirect
 	google.golang.org/api v0.14.0
-	google.golang.org/appengine v1.6.5
-	google.golang.org/genproto v0.0.0-20191115221424-83cc0476cb11
-	google.golang.org/grpc v1.25.1
-	gopkg.in/yaml.v2 v2.2.7
+	google.golang.org/appengine v1.6.5 // indirect
+	google.golang.org/genproto v0.0.0-20191115221424-83cc0476cb11 // indirect
+	google.golang.org/grpc v1.25.1 // indirect
+	gopkg.in/yaml.v2 v2.2.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -26,14 +26,17 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/digitalocean/godo v1.27.0 h1:78iE9oVvTnAEqhMip2UHFvL01b8LJcydbNUpr0cAmN4=
 github.com/digitalocean/godo v1.27.0/go.mod h1:iJnN9rVu6K5LioLxLimlq0uRI+y/eAQjROUmeU/r0hY=
+github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 h1:uHTyIjqVhYRhLbJ8nIiOJHkEZZ+5YoOsAbD3sk82NiE=
@@ -48,6 +51,7 @@ github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -63,13 +67,16 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -81,6 +88,7 @@ github.com/packethost/packngo v0.2.0/go.mod h1:RQHg5xR1F614BwJyepfMqrKN+32IH0i7y
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -101,6 +109,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
@@ -112,6 +121,7 @@ golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5 h1:58fnuSXlxZmFdJyvtTFVmVhcMLU6v5fEb/ok4wyqtNU=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -199,6 +209,7 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
+google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -218,6 +229,7 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1 h1:wdKvqQk7IttEw92GoRyKG2IDrUIpgpj6H6m81yfeMW0=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,0 +1,43 @@
+package env
+
+import (
+	"fmt"
+	"github.com/spf13/pflag"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+func GetRequiredFileOrString(flags *pflag.FlagSet, file, value, envVarName string) (string, error) {
+	return getFileOrString(flags, file, value, envVarName, true)
+}
+
+func getFileOrString(flags *pflag.FlagSet, file, value, envVarName string, required bool) (string, error) {
+	var val string
+
+	authFile, _ := flags.GetString(file)
+	envToken := os.Getenv(envVarName)
+	flagVal, _ := flags.GetString(value)
+
+	if len(authFile) > 0 {
+		// Fallback to the File Flag, then the Env Var
+		res, err := ioutil.ReadFile(authFile)
+		if err != nil {
+			return "", err
+		}
+		val = strings.TrimSpace(string(res))
+	} else {
+		val = flagVal
+	}
+
+	// Finally if val isn't set we can look in the env variable
+	if len(val) == 0 && len(envToken) > 0 {
+		val = strings.TrimSpace(string(envToken))
+	}
+
+	if required && len(val) == 0 {
+		return "", fmt.Errorf("give a value for --%s, --%s or set the environment variable %q", file, value, envVarName)
+	}
+
+	return val, nil
+}

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -1,0 +1,159 @@
+package env
+
+import (
+	"github.com/spf13/pflag"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+)
+
+func Test_GetFileOrString_NoEnvVar_File(t *testing.T) {
+	want := "some contents in this file"
+	file := makeTempFile(want)
+
+	flags := pflag.FlagSet{}
+
+	flags.String("file-flag", file, "")
+
+	got, err := GetRequiredFileOrString(&flags, "file-flag", "value-flag", "TEST_INLETS_NOT_SET")
+
+	if err != nil {
+		t.Errorf("got error when reading file: %s", err.Error())
+	}
+
+	if want != got {
+		t.Errorf("want: %s, but got: %s", want, got)
+	}
+
+}
+
+func Test_GetFileOrString_NoEnvVar_String(t *testing.T) {
+	want := "this-value-is-set"
+	flags := pflag.FlagSet{}
+
+	flags.String("value-flag", want, "")
+
+	got, err := GetRequiredFileOrString(&flags, "file-flag", "value-flag", "TEST_INLETS_NOT_SET")
+
+	if err != nil {
+		t.Errorf("got error when getting value: %s", err.Error())
+	}
+
+	if want != got {
+		t.Errorf("want: %s, but got: %s", want, got)
+	}
+}
+
+func Test_GetFileOrString_NoEnvVar_Nothing(t *testing.T) {
+	flags := pflag.FlagSet{}
+
+	_, err := GetRequiredFileOrString(&flags, "file-flag", "value-flag", "TEST_INLETS_NOT_SET")
+
+	if err == nil {
+		t.Errorf("expected error when trying to get value")
+	}
+
+}
+
+func Test_GetFileOrString_InvalidFile(t *testing.T) {
+	flags := pflag.FlagSet{}
+
+	flags.String("file-flag", "/tmp/non-exists-file", "")
+
+	_, err := GetRequiredFileOrString(&flags, "file-flag", "value-flag", "TEST_INLETS_NOT_SET")
+
+	if err == nil {
+		t.Errorf("expected error when trying to get value")
+	}
+
+}
+
+func Test_GetFileOrString_EnvVar_File(t *testing.T) {
+	want := "env var file should get found"
+	file := makeTempFile(want)
+	envVarName := "WE_SHOULD_FIND_THIS"
+
+	flags := pflag.FlagSet{}
+
+	flags.String("file-flag", file, "")
+
+	os.Setenv(envVarName, file)
+	got, err := GetRequiredFileOrString(&flags, "file-flag", "value-flag", envVarName)
+	os.Unsetenv(envVarName)
+
+	if err != nil {
+		t.Errorf("got error when reading file: %s", err.Error())
+	}
+
+	if want != got {
+		t.Errorf("want: %s, but got: %s", want, got)
+	}
+}
+
+func Test_GetFileOrString_EnvVar_String(t *testing.T) {
+	want := "we-want-this-value"
+	envVarName := "VALUE_FLAG_SHOULD_OVERRIDE_THIS"
+
+	flags := pflag.FlagSet{}
+
+	flags.String("value-flag", want, "")
+
+	os.Setenv(envVarName, "BLANK VALUE")
+	got, err := GetRequiredFileOrString(&flags, "file-flag", "value-flag", envVarName)
+	os.Unsetenv(envVarName)
+
+	if err != nil {
+		t.Errorf("got error when getting value: %s", err.Error())
+	}
+
+	if want != got {
+		t.Errorf("want: %s, but got: %s", want, got)
+	}
+}
+
+func Test_GetFileOrString_EnvVar_Nothing(t *testing.T) {
+	want := "this file has some contents"
+	file := makeTempFile(want)
+	envVarName := "ENV_VAR_SET_NO_FLAGS"
+
+	flags := pflag.FlagSet{}
+
+	os.Setenv(envVarName, file)
+	got, err := GetRequiredFileOrString(&flags, "file-flag", "value-flag", envVarName)
+	os.Unsetenv(envVarName)
+
+	if err != nil {
+		t.Errorf("got error when getting value: %s", err.Error())
+	}
+
+	if file != got {
+		t.Errorf("want: %s, but got: %s", want, got)
+	}
+}
+
+func Test_GetFileOrString_NoVals_NotRequired(t *testing.T) {
+	envVarName := "NO_VALS_ENV_VAR"
+
+	flags := pflag.FlagSet{}
+
+	got, err := getFileOrString(&flags, "file-flag", "value-flag", envVarName, false)
+
+	if err != nil {
+		t.Errorf("got error when getting value: %s", err.Error())
+	}
+
+	if got != "" {
+		t.Errorf("want: \"\" but got: %s", got)
+	}
+}
+
+func makeTempFile(contents string) string {
+	file, err := ioutil.TempFile("", "prefix")
+	if err != nil {
+		log.Fatal(err)
+	}
+	file.Write([]byte(contents))
+
+	return file.Name()
+}

--- a/pkg/provision/ec2.go
+++ b/pkg/provision/ec2.go
@@ -232,7 +232,7 @@ func (p *EC2Provisioner) lookupID(request HostDeleteRequest) (string, error) {
 // creteEC2SecurityGroup creates a security group for the exit-node
 func (p *EC2Provisioner) creteEC2SecurityGroup(controlPort int, pro string) (*string, *string, error) {
 	ports := []int{80, 443, controlPort}
-	proPorts := []int{1024,65535}
+	proPorts := []int{1024, 65535}
 	groupName := "inlets-" + uuid.New().String()
 	group, err := p.ec2Provisioner.CreateSecurityGroup(&ec2.CreateSecurityGroupInput{
 		Description: aws.String("inlets security group"),


### PR DESCRIPTION
## Description

If the env variable INLETS_ACCESS_TOKEN or
INLETS_SECRET_KEY are set then these values will
be used AFTER the values for the flags. As in, if you
don't specify a flag it will see if these exist, if you
set the flag then it won't look in this env variable

Fixes #34 
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

unit tests (100% coverage of new code)

#### Ran the command with:

Env Var set, create & delete work.

Env Var set to something that doesnt exist
Create & delete need the --access-token flag set, and this flag overides the env var (command fail without the flav using the env var file)

Env var not set:
Flags needed

## How are existing users impacted? What migration steps/scripts do we need?
This is an additional flag for users so they dont have to pass `--access-token` or `--secret-key` with every command


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests


