### PR TITLE
Delete exit node provisioned on GCE with the output cmd

### DIFF
--- a/pkg/provision/gce.go
+++ b/pkg/provision/gce.go
@@ -164,10 +164,10 @@ func (p *GCEProvisioner) createInletsFirewallRule(projectID string, firewallRule
 
 // Delete deletes the GCE exit node
 func (p *GCEProvisioner) Delete(request HostDeleteRequest) error {
-	var instanceName string
+	var instanceName, projectID string
 	var err error
 	if len(request.ID) > 0 {
-		instanceName, _, _, err = getGCEFieldsFromID(request.ID)
+		instanceName, _, projectID, err = getGCEFieldsFromID(request.ID)
 		if err != nil {
 			return err
 		}
@@ -176,12 +176,15 @@ func (p *GCEProvisioner) Delete(request HostDeleteRequest) error {
 		if err != nil {
 			return err
 		}
-		instanceName, _, _, err = getGCEFieldsFromID(inletID)
+		instanceName, _, projectID, err = getGCEFieldsFromID(inletID)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = p.gceProvisioner.Instances.Delete(request.ProjectID, request.Zone, instanceName).Do()
+	if len(request.ProjectID) > 0 {
+		projectID = request.ProjectID
+	}
+	_, err = p.gceProvisioner.Instances.Delete(projectID, request.Zone, instanceName).Do()
 	if err != nil {
 		return fmt.Errorf("could not delete the GCE instance: %v", err)
 	}


### PR DESCRIPTION
The delete command printed out after creating an
exit node on GCE does not delete the instance until
a `--project-id` flag is provided.
The project-id should be inferred from the custom instance ID 
and should only be required while creating the exit-node

Closes: #39

Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<img width="1089" alt="Screenshot 2020-01-30 at 4 12 37 PM" src="https://user-images.githubusercontent.com/25264581/73442720-5ab3e980-437b-11ea-9ff0-cf5cd3f2d6f3.png">


## How are existing users impacted? What migration steps/scripts do we need?
Fixes issue: #39 

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
