### PR TITLE
Move all inlets-pro-pkg to inlets-pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Pending:
 Inlets is [listed on the Cloud Native Landscape](https://landscape.cncf.io/category=service-proxy&format=card-mode&grouping=category&sort=stars) as a Service Proxy
 
 * [inlets](https://github.com/inlets/inlets) - open-source L7 HTTP tunnel and reverse proxy
-* [inlets-pro](https://github.com/inlets/inlets-pro-pkg) - L4 TCP load-balancer
+* [inlets-pro](https://github.com/inlets/inlets-pro) - L4 TCP load-balancer
 * [inlets-operator](https://github.com/inlets/inlets-operator) - deep integration for inlets in Kubernetes, expose Service type LoadBalancer
 * [inletsctl](https://github.com/inlets/inletsctl) - CLI tool to provision exit-nodes for use with inlets or inlets-pro
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -344,7 +344,7 @@ curl -sLO https://raw.githubusercontent.com/inlets/inlets/master/hack/inlets-ope
 	export REMOTETCP="` + remoteTCP + `"
 	export IP=$(curl -sfSL https://ifconfig.co)
 	
-	curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro > /tmp/inlets-pro && \
+	curl -SLsf https://github.com/inlets/inlets-pro/releases/download/0.4.3/inlets-pro > /tmp/inlets-pro && \
 	chmod +x /tmp/inlets-pro  && \
 	mv /tmp/inlets-pro /usr/local/bin/inlets-pro
 	

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -48,8 +48,8 @@ func downloadInlets(_ *cobra.Command, _ []string) error {
 	var versionUrl, downloadUrl, binaryName string
 
 	if inletsPro {
-		versionUrl = "https://github.com/inlets/inlets-pro-pkg/releases/latest"
-		downloadUrl = "https://github.com/inlets/inlets-pro-pkg/releases/download/"
+		versionUrl = "https://github.com/inlets/inlets-pro/releases/latest"
+		downloadUrl = "https://github.com/inlets/inlets-pro/releases/download/"
 		binaryName = "inlets-pro"
 	} else {
 		versionUrl = "https://github.com/inlets/inlets/releases/latest"


### PR DESCRIPTION
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

## Description
inlets-pro-pkg was moved to inlets-pro
this updates all references

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`go build && ./inletsctl download` downloaded the binary 
`go build && ./inletsctl download --pro` downloaded the binary

## How are existing users impacted? What migration steps/scripts do we need?
users need to get new inletsctl as inlets-pro-pkg has moved to inlets-pro

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
