### PR TITLE
Added default region when digitalocean provider is being used

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -104,6 +104,8 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 			region = regionVal
 		}
 
+	} else if provider == "digitalocean" {
+		region = "lon1"
 	} else if provider == "scaleway" {
 		region = "fr-par-1"
 	} else if provider == "packet" {


### PR DESCRIPTION
Set to lon1

Signed-off-by: Pablo Caderno <kaderno@gmail.com>

## Description
Added default region value when provider is set to digitalocean and no region is specified.

## How Has This Been Tested?
Code compiled and tested locally ( Ubuntu 19.10 x86_64 /go version go1.12.10 linux/amd64)   and verified it was working as expected. 
`./bin/inletsctl create --provider digitalocean --access-token "XXXXXXXXXXXX"
Using provider: digitalocean
Requesting host: dreamy-feistel2 in lon1, from digitalocean
`

As this a minimal change I don't see any other areas of the code being affected.


## How are existing users impacted? What migration steps/scripts do we need?
Not applicable.

## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests
