### PR TITLE
Fix opening on TCP ports on GCE for inlets-pro and update existing firewall-rules if one already exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /inletsctl
 /bin/**
 .idea/
+.DS_Store

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -311,6 +311,7 @@ func createHost(provider, name, region, zone, projectID, userData, inletsPort st
 				"zone":          zone,
 				"firewall-name": "inlets",
 				"firewall-port": inletsPort,
+				"pro":           fmt.Sprint(pro),
 			},
 		}, nil
 	} else if provider == "ec2" {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	go.opencensus.io v0.22.2 // indirect
-	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5 // indirect
 	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933 // indirect
 	golang.org/x/oauth2 v0.0.0-20191122200657-5d9234df094c
 	golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9 // indirect


### PR DESCRIPTION
Fix opening on TCP ports on GCE for inlets-pro and update existing firewall-rules
if one already exists

Fixes #44
Fixes #56

Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

## Description
This PR will now allow for all TCP traffic through
the inlets-pro exit node
If a firewall-rule for inlets or inlets-pro named 'inlets' already
exists, then it will update the firewall-rule with the
required rules depending on the user using the `--remote-tcp`
flag (inlets-pro) or not in `inletsctl create` command

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Here is an unedited screenshot depicting the update of the `inlets` firewall-rule
and the curl to the exit nodes provisioned with inlets-OSS and inlets-pro running
<img width="1139" alt="Screenshot 2020-02-09 at 5 14 25 PM" src="https://user-images.githubusercontent.com/25264581/74101589-649ad100-4b61-11ea-8b3f-bb53999f6c92.png">
<img width="594" alt="Screenshot 2020-02-09 at 5 09 23 PM" src="https://user-images.githubusercontent.com/25264581/74101596-6c5a7580-4b61-11ea-82fa-6599dcb3f858.png">
<img width="594" alt="Screenshot 2020-02-09 at 5 13 45 PM" src="https://user-images.githubusercontent.com/25264581/74101600-77150a80-4b61-11ea-9e5e-f06653e68309.png">


## How are existing users impacted? What migration steps/scripts do we need?
Users will be able to switch between using inlets and inlets-pro through inletsctl without manually updating the firewall rules.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
