### PR TITLE
Fix get.sh script with case insensitive grep

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -6,7 +6,7 @@ export REPO=inletsctl
 export SUCCESS_CMD="$REPO version"
 export BINLOCATION="/usr/local/bin"
 
-version=$(curl -sI https://github.com/$OWNER/$REPO/releases/latest | grep Location | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
+version=$(curl -sI https://github.com/$OWNER/$REPO/releases/latest | grep -i location | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
 
 if [ ! $version ]; then
     echo "Failed while attempting to install $REPO. Please manually install:"


### PR DESCRIPTION
## Description
Github change the case sensitivity of the location header to lowercase.
This changes the grep on that header to be case insensitive





## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run get.sh befor fix, failed
after fix: success 

## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests