### PR TITLE
support downloading into a folder with a space

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -63,22 +63,22 @@ getPackage() {
         targetFile="$(pwd)/$REPO$suffix"
     fi
 
-    if [ -e $targetFile ]; then
-        rm $targetFile
+    if [ -e "$targetFile" ]; then
+        rm "$targetFile"
     fi
 
     url=https://github.com/$OWNER/$REPO/releases/download/$version/$REPO$suffix
     echo "Downloading package $url as $targetFile"
 
-    curl -sSLf $url --output $targetFile
+    curl -sSLf $url --output "$targetFile"
 
     if [ $? -ne 0 ]; then
         echo "Download Failed!"
         exit 1
     else
-        extractFolder=$(echo $targetFile | sed "s/${REPO}${suffix}//g")
+        extractFolder=$(echo "$targetFile" | sed "s/${REPO}${suffix}//g")
         echo "Download Complete, extracting $targetFile to $extractFolder ..."
-        tar -xzf $targetFile -C $extractFolder
+        tar -xzf "$targetFile" -C "$extractFolder"
     fi
 
     if [ $? -ne 0 ]; then
@@ -87,15 +87,15 @@ getPackage() {
     else
         # Remove the tar file
         echo "OK"
-        rm $targetFile
+        rm "$targetFile"
 
         # Get the parent dir of the 'bin' folder holding the binary
-        targetFile=$(echo $targetFile | sed "s+/${REPO}${suffix}++g")
+        targetFile=$(echo "$targetFile" | sed "s+/${REPO}${suffix}++g")
         suffix=$(echo $suffix | sed 's/.tgz//g')
 
         targetFile="${targetFile}/bin/${REPO}${suffix}"
 
-        chmod +x $targetFile
+        chmod +x "$targetFile"
 
         # Calculate SHA
         shaurl=$(echo $url | sed 's/.tgz/.sha256/g')
@@ -126,14 +126,14 @@ getPackage() {
                 echo
                 echo "Running with sufficient permissions to attempt to move $REPO to $BINLOCATION"
 
-                mv $targetFile $BINLOCATION/$REPO
+                mv "$targetFile" $BINLOCATION/$REPO
 
                 if [ "$?" = "0" ]; then
                     echo "New version of $REPO installed to $BINLOCATION"
                 fi
 
-                if [ -e $targetFile ]; then
-                    rm $targetFile
+                if [ -e "$targetFile" ]; then
+                    rm "$targetFile"
                 fi
 
             ${SUCCESS_CMD}


### PR DESCRIPTION
Signed-off-by: wingkwong <wingkwong.code@gmail.com>

## Description
support for downloading ineltsctl into a folder with space.

## How Has This Been Tested?
Before:
```
test folder with space wingkwong$ ../get.sh 
../get.sh: line 66: [: too many arguments
Downloading package https://github.com/inlets/inletsctl/releases/download/0.5.2/inletsctl-darwin.tgz as /Users/wingkwong/Documents/GitHub/inletsctl/test folder with space/inletsctl-darwin.tgz
curl: (6) Could not resolve host: folder
curl: (6) Could not resolve host: with
curl: (6) Could not resolve host: space
Download Failed!
```

After:
```
test folder with space wingkwong$ ../get.sh 
Downloading package https://github.com/inlets/inletsctl/releases/download/0.5.2/inletsctl-darwin.tgz as /Users/wingkwong/Documents/GitHub/inletsctl/test folder with space/inletsctl-darwin.tgz
Download Complete, extracting /Users/wingkwong/Documents/GitHub/inletsctl/test folder with space/inletsctl-darwin.tgz to /Users/wingkwong/Documents/GitHub/inletsctl/test folder with space/ ...
OK
SHA256 fetched from release: 390702b416ec6df83792c76e2f24bc648c78d6d9ce5b91800eb927e7538e4fd3

Running with sufficient permissions to attempt to move inletsctl to /usr/local/bin
New version of inletsctl installed to /usr/local/bin
 _       _      _            _   _ 
(_)_ __ | | ___| |_ ___  ___| |_| |
| | '_ \| |/ _ \ __/ __|/ __| __| |
| | | | | |  __/ |_\__ \ (__| |_| |
|_|_| |_|_|\___|\__|___/\___|\__|_|

Version: 0.5.2
Git Commit: 1744d8982db69d919eb75041a5edda3d670eea28
```

## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
