### PR TITLE
Azure provisioner factory to take auth contents as parameter

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -151,13 +151,11 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 	}
 
 	var subscriptionID string
-	var accessTokenFile string
 	if provider == "azure" {
 		subscriptionID, _ = cmd.Flags().GetString("subscription-id")
-		accessTokenFile, _ = cmd.Flags().GetString("access-token-file")
 	}
 
-	provisioner, err := getProvisioner(provider, accessToken, accessTokenFile, secretKey, organisationID, region, subscriptionID)
+	provisioner, err := getProvisioner(provider, accessToken, secretKey, organisationID, region, subscriptionID)
 
 	if err != nil {
 		return err
@@ -246,7 +244,7 @@ To Delete:
 	return err
 }
 
-func getProvisioner(provider, accessToken, accessTokenFile, secretKey, organisationID, region, subscriptionID string) (provision.Provisioner, error) {
+func getProvisioner(provider, accessToken, secretKey, organisationID, region, subscriptionID string) (provision.Provisioner, error) {
 	if provider == "digitalocean" {
 		return provision.NewDigitalOceanProvisioner(accessToken)
 	} else if provider == "packet" {
@@ -260,7 +258,7 @@ func getProvisioner(provider, accessToken, accessTokenFile, secretKey, organisat
 	} else if provider == "ec2" {
 		return provision.NewEC2Provisioner(region, accessToken, secretKey)
 	} else if provider == "azure" {
-		return provision.NewAzureProvisioner(subscriptionID, accessTokenFile)
+		return provision.NewAzureProvisioner(subscriptionID, accessToken)
 	} else if provider == "linode" {
 		return provision.NewLinodeProvisioner(accessToken)
 	}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -99,13 +99,11 @@ func runDelete(cmd *cobra.Command, _ []string) error {
 	}
 
 	var subscriptionID string
-	var accessTokenFile string
 	if provider == "azure" {
 		subscriptionID, _ = cmd.Flags().GetString("subscription-id")
-		accessTokenFile, _ = cmd.Flags().GetString("access-token-file")
 	}
 
-	provisioner, err := getProvisioner(provider, accessToken, accessTokenFile, secretKey, organisationID, region, subscriptionID)
+	provisioner, err := getProvisioner(provider, accessToken, secretKey, organisationID, region, subscriptionID)
 
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/alexellis/go-execute v0.0.0-20191029181357-d17947259f74
 	github.com/aws/aws-sdk-go v1.26.8
 	github.com/digitalocean/godo v1.27.0
+	github.com/dimchansky/utfbom v1.1.0
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
 	github.com/golang/mock v1.3.1
 	github.com/google/uuid v1.1.1

--- a/pkg/provision/azure_test.go
+++ b/pkg/provision/azure_test.go
@@ -4,13 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/google/uuid"
 	"testing"
 )
 
-func Test_Azure_Auth_File_Not_Existing(t *testing.T) {
-	nonExistentFile := "/non-existent-" + uuid.New().String()
-	_, err := NewAzureProvisioner("SubscriptionID", nonExistentFile)
+func Test_Azure_Auth_Contents_Invalid(t *testing.T) {
+	_, err := NewAzureProvisioner("SubscriptionID", "invalid contents")
 
 	if err == nil {
 		t.Errorf("want: error, but got: nil")


### PR DESCRIPTION
The 2nd parameter of Azure provisioner factory is changed to using auth file contents instead of auth file path. And internally the contents will be translated into environment variables, and because of that, NewAuthorizerFromFile is replaced by NewAuthorizerFromEnvironment.

Signed-off-by: Ze Chen <zechenbit@gmail.com>

## Description
Will close #69 


## How Has This Been Tested?
### Create:
```
inletsctl create --provider=azure --subscription-id=<id> --region=eastus --access-token-file=~/client_credentials.json 

Using provider: azure
Requesting host: compassionate-franklin3 in eastus, from azure
2020/07/19 12:04:55 Provisioning host with Azure
2020/07/19 12:04:55 Creating resource group inlets-compassionate-franklin3
2020/07/19 12:04:59 Resource group created inlets-compassionate-franklin3
2020/07/19 12:04:59 Creating deployment inlets-deploy-208a7c51-fcfb-4d56-96b0-3f844fa5fae7
Host: inlets-compassionate-franklin3, status: active
[1/500] Host: inlets-compassionate-franklin3, status: Running
[2/500] Host: inlets-compassionate-franklin3, status: Running
[3/500] Host: inlets-compassionate-franklin3, status: Running
[4/500] Host: inlets-compassionate-franklin3, status: Running
[5/500] Host: inlets-compassionate-franklin3, status: Running
[6/500] Host: inlets-compassionate-franklin3, status: Running
[7/500] Host: inlets-compassionate-franklin3, status: Running
[8/500] Host: inlets-compassionate-franklin3, status: Running
[9/500] Host: inlets-compassionate-franklin3, status: Running
[10/500] Host: inlets-compassionate-franklin3, status: Running
[11/500] Host: inlets-compassionate-franklin3, status: Running
[12/500] Host: inlets-compassionate-franklin3, status: Running
[13/500] Host: inlets-compassionate-franklin3, status: Running
[14/500] Host: inlets-compassionate-franklin3, status: Running
[15/500] Host: inlets-compassionate-franklin3, status: Running
[16/500] Host: inlets-compassionate-franklin3, status: Running
[17/500] Host: inlets-compassionate-franklin3, status: Running
[18/500] Host: inlets-compassionate-franklin3, status: Running
[19/500] Host: inlets-compassionate-franklin3, status: Running
[20/500] Host: inlets-compassionate-franklin3, status: Running
[21/500] Host: inlets-compassionate-franklin3, status: Running
[22/500] Host: inlets-compassionate-franklin3, status: Running
[23/500] Host: inlets-compassionate-franklin3, status: Running
[24/500] Host: inlets-compassionate-franklin3, status: Running
[25/500] Host: inlets-compassionate-franklin3, status: Running
[26/500] Host: inlets-compassionate-franklin3, status: Running
[27/500] Host: inlets-compassionate-franklin3, status: Running
[28/500] Host: inlets-compassionate-franklin3, status: Running
[29/500] Host: inlets-compassionate-franklin3, status: active
Inlets OSS exit-node summary:
  IP: 40.88.12.80
  Auth-token: VXpSyXoFCXr7eO8vlYClel7YFU5aDnxCGAm3aW50Sa1Qaa5Ta7rUQJEvTLhVugyB

Command:
  export UPSTREAM=http://127.0.0.1:8000
  inlets client --remote "ws://40.88.12.80:8080" \
        --token "VXpSyXoFCXr7eO8vlYClel7YFU5aDnxCGAm3aW50Sa1Qaa5Ta7rUQJEvTLhVugyB" \
        --upstream $UPSTREAM

To Delete:
        inletsctl delete --provider azure --id "inlets-compassionate-franklin3"
```

### Delete
```
inletsctl delete --provider=azure --id=inlets-compassionate-franklin3 --subscription-id=<id> --region=eastasia --access-token-file=~/client_credentials.json
Using provider: azure
Deleting host: inlets-compassionate-franklin3 from azure
```
## How are existing users impacted? What migration steps/scripts do we need?
No users will be impacted as the command line won't be changed.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
