### PR TITLE
Use Azure group and deployment name as host ID

### DIFF
--- a/pkg/provision/azure_test.go
+++ b/pkg/provision/azure_test.go
@@ -15,6 +15,33 @@ func Test_Azure_Auth_Contents_Invalid(t *testing.T) {
 	}
 }
 
+func Test_Azure_Build_Group_Deployment_Name(t *testing.T) {
+	hostID := buildAzureHostID("inlets-peaceful-chaum1", "deployments-e589c808-3936-4bd9-b558-36640eb98cb0")
+	if hostID != "inlets-peaceful-chaum1|deployments-e589c808-3936-4bd9-b558-36640eb98cb0" {
+		t.Errorf("want: inlets-peaceful-chaum1|deployments-e589c808-3936-4bd9-b558-36640eb98cb, but got: %s", hostID)
+	}
+}
+
+func Test_Azure_Parse_Group_Deployment_Name_Success(t *testing.T) {
+	resourceGroupName, deploymentName, err := getAzureFieldsFromID("inlets-peaceful-chaum1|deployments-e589c808-3936-4bd9-b558-36640eb98cb0")
+	if err != nil {
+		t.Errorf("want: nil, but got: %s", err.Error())
+	}
+	if resourceGroupName != "inlets-peaceful-chaum1" {
+		t.Errorf("want: inlets-peaceful-chaum1, but got: %s", resourceGroupName)
+	}
+	if deploymentName != "deployments-e589c808-3936-4bd9-b558-36640eb98cb0" {
+		t.Errorf("want: deployments-e589c808-3936-4bd9-b558-36640eb98cb0, but got: %s", deploymentName)
+	}
+}
+
+func Test_Azure_Parse_Group_Deployment_Name_Fail(t *testing.T) {
+	_, _, err := getAzureFieldsFromID("INVALID_ID")
+	if err == nil {
+		t.Errorf("want: error, but got nil")
+	}
+}
+
 func Test_Azure_Template(t *testing.T) {
 	want := map[string]interface{}{
 		"$schema":        "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
@@ -241,19 +268,6 @@ func Test_Azure_Parameters(t *testing.T) {
 		},
 		"networkSecurityGroupRules": map[string]interface{}{
 			"value": []interface{}{
-				map[string]interface{}{
-					"name": "SSH",
-					"properties": map[string]interface{}{
-						"access":                   "Allow",
-						"destinationAddressPrefix": "*",
-						"destinationPortRange":     "22",
-						"direction":                "Inbound",
-						"priority":                 300,
-						"protocol":                 "TCP",
-						"sourceAddressPrefix":      "*",
-						"sourcePortRange":          "*",
-					},
-				},
 				map[string]interface{}{
 					"name": "HTTPS",
 					"properties": map[string]interface{}{


### PR DESCRIPTION
Group name and deployment name are now used
together to build Azure host ID. So that the
group name and deployment can be retrieved
easily later for status and delete operations.

Signed-off-by: Ze Chen <zechenbit@gmail.com>

## Description
Previously the host ID is the Azure resource group name, while it is working when using inletsctl as a standalone tool, this host ID makes it impossible to get deployment status when being consumed in `inlets-operator` because we use deployment name instead of resource group name to retrieve the status.

The solution is to put both the resource group name and deployment into the Azure host ID, so that the ID can be used to retrieve resource group name and deployment name.

An example is `inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce`.


## How Has This Been Tested?
### Create
```
inletsctl create -provider=azure --subscription-id=<subscription id> --region=eastus --access-token-file=~/client_credentials.json
Using provider: azure
Requesting host: dreamy-chatelet5 in eastus, from azure
2020/07/28 23:34:59 Provisioning host with Azure
2020/07/28 23:34:59 Creating resource group inlets-dreamy-chatelet5
2020/07/28 23:35:02 Resource group created inlets-dreamy-chatelet5
2020/07/28 23:35:02 Creating deployment deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce
Host: inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce, status: active
[1/500] Host: inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce, status: Running
[2/500] Host: inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce, status: Running
[3/500] Host: inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce, status: Running
[4/500] Host: inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce, status: Running
[5/500] Host: inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce, status: Running
[6/500] Host: inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce, status: Running
[7/500] Host: inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce, status: Running
[8/500] Host: inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce, status: Running
[9/500] Host: inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce, status: Running
[10/500] Host: inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce, status: Running
[11/500] Host: inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce, status: Running
[12/500] Host: inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce, status: active
Inlets OSS exit-node summary:
  IP: 52.179.22.49
  Auth-token: wO6nS1YizLNWgBDJusGzCwndvPUF1Srji4CxL40CKwUvEuYJ072urSFz2UMyBvau

Command:
  export UPSTREAM=http://127.0.0.1:8000
  inlets client --remote "ws://52.179.22.49:8080" \
        --token "wO6nS1YizLNWgBDJusGzCwndvPUF1Srji4CxL40CKwUvEuYJ072urSFz2UMyBvau" \
        --upstream $UPSTREAM

To Delete:
        inletsctl delete --provider azure --id "inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce"
```

### Delete
```
inletsctl delete --provider=azure --id="inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce" --subscription-id=<Subscription ID> --region=eastasia --access-token-file=~/client_credentials.json
Using provider: azure
Deleting host: inlets-dreamy-chatelet5|deployment-d95e7fbf-e56d-4f1f-b3e3-fdaae33730ce from azure
```

## How are existing users impacted? What migration steps/scripts do we need?
N/A

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
