### PR TITLE
Hetzner provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Completed:
 * [x] Provisioner: AWS EC2
 * [x] Provisioner: Azure
 * [x] Provisioner: Linode
+* [x] Provisioner: Hetzner
 * [x] `inletsctl delete` command
 * [x] Add poll interval `--poll 5s` for use with Civo that applies rate-limiting
 * [x] Install `inlets/inlets-pro` via `inletsctl download` [#12](https://github.com/inlets/inletsctl/issues/12)

--- a/README.md
+++ b/README.md
@@ -200,6 +200,19 @@ inletsctl create --provider scaleway \
 
 The region is hard-coded to France / Paris 1.
 
+### Example usage with Hetzner
+
+```sh
+# Obtain the API token from Hetzner Cloud Console.
+export TOKEN=""
+
+inletsctl create --provider hetzner \
+  --access-token $TOKEN \
+  --region hel1
+```
+
+Available regions are `hel1` (Helsinki), `nur1` (Nuremberg), `fsn1` (Falkenstein).
+
 ## Examples for `inletsctl kfwd`
 
 The `inletsctl kfwd` command can port-forward services from within your local Kubernetes cluster to your local network or computer.

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -27,7 +27,7 @@ func init() {
 
 	inletsCmd.AddCommand(createCmd)
 
-	createCmd.Flags().StringP("provider", "p", "digitalocean", "The cloud provider - digitalocean, gce, ec2, azure, packet, scaleway, linode or civo")
+	createCmd.Flags().StringP("provider", "p", "digitalocean", "The cloud provider - digitalocean, gce, ec2, azure, packet, scaleway, linode, civo or hetzner")
 	createCmd.Flags().StringP("region", "r", "lon1", "The region for your cloud provider")
 	createCmd.Flags().StringP("zone", "z", "us-central1-a", "The zone for the exit node (Google Compute Engine)")
 
@@ -54,7 +54,7 @@ var createCmd = &cobra.Command{
 along with what OS version and spec will be used is explained in the README.
 `,
 	Example: `  inletsctl create  \
-	--provider [digitalocean|packet|ec2|scaleway|civo|gce|azure|linode] \
+	--provider [digitalocean|packet|ec2|scaleway|civo|gce|azure|linode|hetzner] \
 	--access-token-file $HOME/access-token \
 	--region lon1
 
@@ -119,6 +119,8 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 		region = "ams1"
 	} else if provider == "ec2" {
 		region = "eu-west-1"
+	} else if provider == "hetzner" {
+		region = "hel1"
 	}
 
 	var zone string
@@ -261,6 +263,8 @@ func getProvisioner(provider, accessToken, secretKey, organisationID, region, su
 		return provision.NewAzureProvisioner(subscriptionID, accessToken)
 	} else if provider == "linode" {
 		return provision.NewLinodeProvisioner(accessToken)
+	} else if provider == "hetzner" {
+		return provision.NewHetznerProvisioner(accessToken)
 	}
 	return nil, fmt.Errorf("no provisioner for provider: %s", provider)
 }
@@ -374,6 +378,14 @@ func createHost(provider, name, region, zone, projectID, userData, inletsPort st
 				"inlets-port": inletsPort,
 				"pro":         fmt.Sprint(pro),
 			},
+		}, nil
+	} else if provider == "hetzner" {
+		return &provision.BasicHost{
+			Name:       name,
+			Region:     region,
+			Plan:       "cx11",
+			OS:         "ubuntu-20.04",
+			UserData:   userData,
 		}, nil
 	}
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -380,6 +380,11 @@ func createHost(provider, name, region, zone, projectID, userData, inletsPort st
 			},
 		}, nil
 	} else if provider == "hetzner" {
+		// Easiest way to get the information of available images and server types is through
+		// the Hetzner API, but it requires auth for any type of call.
+		// Images can be fetched from https://api.hetzner.cloud/v1/images
+		// Server types can be fetched from https://api.hetzner.cloud/v1/server_types
+		// The regions available are hel1 (Helsinki), nur1 (Nuremberg), fsn1 (Falkenstein)
 		return &provision.BasicHost{
 			Name:     name,
 			Region:   region,

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -381,11 +381,11 @@ func createHost(provider, name, region, zone, projectID, userData, inletsPort st
 		}, nil
 	} else if provider == "hetzner" {
 		return &provision.BasicHost{
-			Name:       name,
-			Region:     region,
-			Plan:       "cx11",
-			OS:         "ubuntu-20.04",
-			UserData:   userData,
+			Name:     name,
+			Region:   region,
+			Plan:     "cx11",
+			OS:       "ubuntu-16.04",
+			UserData: userData,
 		}, nil
 	}
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -13,7 +13,7 @@ import (
 
 func init() {
 	inletsCmd.AddCommand(deleteCmd)
-	deleteCmd.Flags().StringP("provider", "p", "digitalocean", "The cloud provider - digitalocean, gce, ec2, azure, packet, scaleway, linode or civo")
+	deleteCmd.Flags().StringP("provider", "p", "digitalocean", "The cloud provider - digitalocean, gce, ec2, azure, packet, scaleway, linode, civo or hetzner")
 	deleteCmd.Flags().StringP("region", "r", "lon1", "The region for your cloud provider")
 	deleteCmd.Flags().StringP("zone", "z", "us-central1-a", "The zone for the exit node (Google Compute Engine)")
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
 	github.com/golang/mock v1.3.1
 	github.com/google/uuid v1.1.1
+	github.com/hetznercloud/hcloud-go v1.18.2
 	github.com/linode/linodego v0.19.0
 	github.com/morikuni/aec v1.0.0
 	github.com/packethost/packngo v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,7 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hetznercloud/hcloud-go v1.18.2 h1:ZCDJHCqKqfT3SnZ+kESVqmqh8QgoTqjnddt7g3v5Yfs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,7 @@ github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -132,6 +133,7 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hetznercloud/hcloud-go v1.18.2 h1:ZCDJHCqKqfT3SnZ+kESVqmqh8QgoTqjnddt7g3v5Yfs=
+github.com/hetznercloud/hcloud-go v1.18.2/go.mod h1:EhElojlVU1biA5JgBaV8rRU1vE5+iYke402kXC9pooE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/pkg/provision/README.md
+++ b/pkg/provision/README.md
@@ -42,3 +42,4 @@ If you would like to add a provider please propose it with an Issue, to make sur
 * AWS EC2 - [adamjohnson01](https://github.com/adamjohnson01/)
 * GCE - [utsavanand2](https://github.com/utsavanand2/)
 * Azure, Linode - [zechenbit](https://github.com/zechenbit/)
+* Hetzner [Johannestegner](https://github.com/johannestegner)

--- a/pkg/provision/hetzner.go
+++ b/pkg/provision/hetzner.go
@@ -8,7 +8,6 @@ import (
 )
 
 var Status = "running"
-var defaultInstanceName = "CX11"
 
 type HetznerProvisioner struct {
 	client *hcloud.Client
@@ -32,7 +31,7 @@ func (p *HetznerProvisioner) Status(id string) (*ProvisionedHost, error) {
 	if err != nil {
 		return nil, err
 	}
-	if server != nil {
+	if server == nil {
 		return nil, fmt.Errorf("failed to find server with id %s", id)
 	}
 
@@ -56,13 +55,13 @@ func (p *HetznerProvisioner) Status(id string) (*ProvisionedHost, error) {
 // Provision a new server on Hetzner cloud to use as an inlet node.
 func (p *HetznerProvisioner) Provision(host BasicHost) (*ProvisionedHost, error) {
 	if len(host.Plan) <= 0 {
-		host.Plan = defaultInstanceName
+		host.Plan = "cx11"
 	}
 	if len(host.Region) <= 0 {
 		host.Region = "hel1"
 	}
 
-	img, _, err := p.client.Image.GetByName(context.Background(), host.Plan)
+	img, _, err := p.client.Image.GetByName(context.Background(), host.OS)
 	loc, _, err := p.client.Location.GetByName(context.Background(), host.Region)
 	pln, _, err := p.client.ServerType.GetByName(context.Background(), host.Plan)
 

--- a/pkg/provision/hetzner.go
+++ b/pkg/provision/hetzner.go
@@ -54,13 +54,6 @@ func (p *HetznerProvisioner) Status(id string) (*ProvisionedHost, error) {
 
 // Provision a new server on Hetzner cloud to use as an inlet node.
 func (p *HetznerProvisioner) Provision(host BasicHost) (*ProvisionedHost, error) {
-	if len(host.Plan) <= 0 {
-		host.Plan = "cx11"
-	}
-	if len(host.Region) <= 0 {
-		host.Region = "hel1"
-	}
-
 	img, _, err := p.client.Image.GetByName(context.Background(), host.OS)
 	loc, _, err := p.client.Location.GetByName(context.Background(), host.Region)
 	pln, _, err := p.client.ServerType.GetByName(context.Background(), host.Plan)

--- a/pkg/provision/hetzner.go
+++ b/pkg/provision/hetzner.go
@@ -89,6 +89,8 @@ func (p *HetznerProvisioner) Provision(host BasicHost) (*ProvisionedHost, error)
 func (p *HetznerProvisioner) List(filter ListFilter) ([]*ProvisionedHost, error) {
 	var hosts []*ProvisionedHost
 	hostList, err := p.client.Server.AllWithOpts(context.Background(), hcloud.ServerListOpts{
+		// Adding a label to the VPS so that it is easier to select inlets managed servers and also
+		// to tell the user that the server in question is managed by inlets.
 		ListOpts: hcloud.ListOpts{
 			LabelSelector: "managed-by=inlets",
 		},
@@ -122,10 +124,9 @@ func (p *HetznerProvisioner) Delete(request HostDeleteRequest) error {
 				id = instance.ID
 			}
 		}
-	}
-
-	if len(id) <= 0 {
-		return fmt.Errorf("failed to find server with id %s", id)
+		if len(id) <= 0 {
+			return fmt.Errorf("failed to find server with id with IP %s", request.IP)
+		}
 	}
 
 	idAsInt, err := strconv.Atoi(id)

--- a/pkg/provision/hetzner.go
+++ b/pkg/provision/hetzner.go
@@ -1,3 +1,154 @@
 package provision
 
-import "github.com/hetznercloud/hcloud-go"
+import (
+	"context"
+	"fmt"
+	"github.com/hetznercloud/hcloud-go/hcloud"
+	"strconv"
+)
+
+var Status = "running"
+var defaultInstanceName = "CX11"
+
+type HetznerProvisioner struct {
+	client *hcloud.Client
+}
+
+// Creates a new Hetzner provisioner using an auth token.
+func NewHetznerProvisioner(authToken string) (*HetznerProvisioner, error) {
+	client := hcloud.NewClient(hcloud.WithToken(authToken))
+	return &HetznerProvisioner{
+		client: client,
+	}, nil
+}
+
+// Get status of a specific server by id.
+func (p *HetznerProvisioner) Status(id string) (*ProvisionedHost, error) {
+	intId, err := strconv.Atoi(id)
+	if err != nil {
+		return nil, err
+	}
+	server, _, err := p.client.Server.GetByID(context.Background(), intId)
+	if err != nil {
+		return nil, err
+	}
+	if server != nil {
+		return nil, fmt.Errorf("failed to find server with id %s", id)
+	}
+
+	status := ""
+	ip := ""
+
+	if server.Status == hcloud.ServerStatusRunning {
+		status = ActiveStatus
+		ip = server.PublicNet.IPv4.IP.String()
+	} else {
+		status = string(server.Status)
+	}
+
+	return &ProvisionedHost{
+		IP:     ip,
+		ID:     id,
+		Status: status,
+	}, nil
+}
+
+// Provision a new server on Hetzner cloud to use as an inlet node.
+func (p *HetznerProvisioner) Provision(host BasicHost) (*ProvisionedHost, error) {
+	if len(host.Plan) <= 0 {
+		host.Plan = defaultInstanceName
+	}
+	if len(host.Region) <= 0 {
+		host.Region = "hel1"
+	}
+
+	img, _, err := p.client.Image.GetByName(context.Background(), host.Plan)
+	loc, _, err := p.client.Location.GetByName(context.Background(), host.Region)
+	pln, _, err := p.client.ServerType.GetByName(context.Background(), host.Plan)
+
+	if err != nil {
+		return nil, err
+	}
+
+	server, _, err := p.client.Server.Create(context.Background(), hcloud.ServerCreateOpts{
+		Name:             host.Name,
+		ServerType:       pln,
+		Image:            img,
+		Location:         loc,
+		UserData:         host.UserData,
+		StartAfterCreate: hcloud.Bool(true),
+		Labels: map[string]string{
+			"managed-by": "inlets",
+		},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &ProvisionedHost{
+		IP:     server.Server.PublicNet.IPv4.IP.String(),
+		ID:     strconv.Itoa(server.Server.ID),
+		Status: "creating",
+	}, nil
+}
+
+// List all nodes that are managed by inlets.
+func (p *HetznerProvisioner) List(filter ListFilter) ([]*ProvisionedHost, error) {
+	var hosts []*ProvisionedHost
+	hostList, err := p.client.Server.AllWithOpts(context.Background(), hcloud.ServerListOpts{
+		ListOpts: hcloud.ListOpts{
+			LabelSelector: "managed-by=inlets",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, instance := range hostList {
+		hosts = append(hosts, &ProvisionedHost{
+			IP:     instance.PublicNet.IPv4.IP.String(),
+			ID:     strconv.Itoa(instance.ID),
+			Status: string(instance.Status),
+		})
+	}
+
+	return hosts, nil
+}
+
+// Delete a specific server from the Hetzner cloud.
+func (p* HetznerProvisioner) Delete(request HostDeleteRequest) error {
+	id := request.ID
+	if len(id) <= 0 {
+		hosts, err := p.List(ListFilter{})
+		if err != nil {
+			return err
+		}
+		for _, instance := range hosts {
+			if instance.IP == request.IP {
+				id = instance.ID
+			}
+		}
+	}
+
+	if len(id) <= 0 {
+		return fmt.Errorf("failed to find server with id %s", id)
+	}
+
+	idAsInt, err := strconv.Atoi(id)
+	if err != nil {
+		return err
+	}
+
+	server, _, err := p.client.Server.GetByID(context.Background(), idAsInt)
+	if err != nil {
+		return err
+	}
+
+	_, err = p.client.Server.Delete(context.Background(), server)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/provision/hetzner.go
+++ b/pkg/provision/hetzner.go
@@ -1,0 +1,3 @@
+package provision
+
+import "github.com/hetznercloud/hcloud-go"

--- a/pkg/provision/hetzner.go
+++ b/pkg/provision/hetzner.go
@@ -100,6 +100,7 @@ func (p *HetznerProvisioner) List(filter ListFilter) ([]*ProvisionedHost, error)
 			LabelSelector: "managed-by=inlets",
 		},
 	})
+
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +117,7 @@ func (p *HetznerProvisioner) List(filter ListFilter) ([]*ProvisionedHost, error)
 }
 
 // Delete a specific server from the Hetzner cloud.
-func (p* HetznerProvisioner) Delete(request HostDeleteRequest) error {
+func (p *HetznerProvisioner) Delete(request HostDeleteRequest) error {
 	id := request.ID
 	if len(id) <= 0 {
 		hosts, err := p.List(ListFilter{})
@@ -142,6 +143,10 @@ func (p* HetznerProvisioner) Delete(request HostDeleteRequest) error {
 	server, _, err := p.client.Server.GetByID(context.Background(), idAsInt)
 	if err != nil {
 		return err
+	}
+
+	if server == nil {
+		return fmt.Errorf("failed to find server with id %s", id)
 	}
 
 	_, err = p.client.Server.Delete(context.Background(), server)


### PR DESCRIPTION
## Description

This pull request contains code which allows for provisioning of the cheapest server type at Hetzner cloud to be used as an inlet end node.

I made the default region hel1 (Helsinki, Finland) and the server type is the cx11 (€2.49/month) with Ubuntu 20.04.

This should close #67 if accepted.

## How Has This Been Tested?

I tested the provider manually multiple times on Windows 10 Pro and on Ubuntu 18.04 (via WSL2).  
The following steps was taken:

1. Docker container with nginx was set up with port 8000 exposed.  
2. Inletctl was ran with the new provider and available flags, using access token from Hetzner web interface.  
3. Visited the IP of the hertzner provisioned machine, which showed the correct nginx startup screen.
4. Closed the docker container.
5. Visited the IP of the hertzner provisioned machine, which no longer shows the nginx startup screen.
6. Ran delete command and verified that the machine was in fact removed.

---

_Edit after testing with latest commits:_

Used the same procedure as above, with all available regions, with same successful result.  

## How are existing users impacted? What migration steps/scripts do we need?

No changes, only a new provider added.

## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests
