### PR TITLE
Proposed fixes for ec2 provider create with non-default VPC. Closes #…

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,7 @@ github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=


### PR DESCRIPTION
…73 and #74.

## Description

These changes are proposed fixes for issues #73 and #74. If maintainers are happy with proposed changes I'll commit to updating documentation or whatever other changes are prudent. I should note that I'm a golang novice so feedback on the provide code changes is welcome!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with this PR's code changes via:
```
 ./inletsctl create -f ~/Downloads/access-key --secret-key-file ~/Downloads/secret-access-key -r us-west-2 -p ec2 --vpc-id vpc-f12e6b88 --subnet-id subnet-89ef61d3
```
By providing the new args `vpc-id` and `subnet-id`, I was able to successfully create the exit node and accompanying security group.

## How are existing users impacted? What migration steps/scripts do we need?

With these changes users that target the `ec2` provider will now have the option to include the new `vpc-id` and `subnet-id` args. By providing these args users with no default VPC will no longer face an error during exit node creation. They also allow users to have more control over the placement of the exit node.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
