### PR TITLE
Update for inlets PRO 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ gcloud iam service-accounts keys create key.json \
 inletsctl create -p gce --project-id=$PROJECTID -f=key.json
 
 ## Create a TCP tunnel with inlets-pro
-inletsctl create -p gce -p $PROJECTID --remote-tcp=127.0.0.1 -f=key.json
+inletsctl create -p gce -p $PROJECTID -f=key.json
 
 # Or specify any valid Google Cloud Zone optional zone, by default it get provisioned in us-central1-a
 inletsctl create -p gce --project-id=$PROJECTID -f key.json --zone=us-central1-a
@@ -178,12 +178,14 @@ inletsctl create --access-token-file $HOME/Downloads/do-access-token \
 
 ### Example with inlets-pro
 
-Let's say we want to forward TCP connections to the IP `192.168.0.26` within our client's network, using inlets-pro, we'd run this using the `--remote-tcp` flag.
-
 ```sh
-inletsctl create digitalocean --access-token-file ~/Downloads/do-access-token \
-  --remote-tcp 192.168.0.26
+inletsctl create \
+  --provider digitalocean \
+  --access-token-file ~/Downloads/do-access-token \
+  --pro
 ```
+
+Then make sure you pass the `--upstream` variable to the inlets PRO client with the message displayed after creation.
 
 ### Example usage with Scaleway
 

--- a/cmd/kfwd.go
+++ b/cmd/kfwd.go
@@ -23,7 +23,8 @@ func init() {
 	kfwdCmd.Flags().StringP("from", "f", "", "From service for the inlets client to forward")
 	kfwdCmd.Flags().StringP("if", "i", "", "Destination interface for the inlets server")
 	kfwdCmd.Flags().StringP("namespace", "n", "default", "Source service namespace")
-
+	kfwdCmd.Flags().String("license", "", "Inlets PRO license key")
+	kfwdCmd.Flags().Bool("pro", false, "Use inlets PRO")
 }
 
 // clientCmd represents the client sub command.
@@ -40,7 +41,91 @@ specify an ethernet address accessible from within the Kubernetes cluster`,
 	SilenceErrors: true,
 }
 
+func fwdPro(cmd *cobra.Command, eth, port, upstream, ns, inletsToken, license string) error {
+
+	deployment := makeProDeployment(eth, port, upstream, ns, inletsToken, license)
+	tmpPath := path.Join(os.TempDir(), "inlets-"+upstream+".yaml")
+	err := ioutil.WriteFile(tmpPath, []byte(deployment), 0600)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s written.\n", tmpPath)
+
+	task := v1.ExecTask{
+		Command: "kubectl",
+		Args:    []string{"apply", "-f", tmpPath},
+	}
+	res, err := task.Execute()
+	if err != nil {
+		return err
+	}
+
+	if res.ExitCode != 0 {
+		return fmt.Errorf("exit code unexpected: %d, stderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	fmt.Println("inlets PRO client scheduled inside your cluster.")
+
+	go func() {
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, syscall.SIGTERM)
+		signal.Notify(sig, syscall.SIGINT)
+
+		<-sig
+
+		log.Printf("Interrupt received..\n")
+
+		task := v1.ExecTask{
+			Command: "kubectl",
+			Args:    []string{"delete", "-f", tmpPath},
+		}
+		res, err := task.Execute()
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, err.Error())
+			return
+		}
+
+		if res.ExitCode != 0 {
+			fmt.Fprintf(os.Stderr, fmt.Errorf("exit code unexpected from kubectl delete: %d, stderr: %s", res.ExitCode, res.Stderr).Error())
+			return
+		}
+	}()
+
+	fmt.Printf(`inlets PRO server now listening.
+
+%s:%s
+
+Hit Control+C to cancel.
+`, eth, port)
+
+	serverTask := v1.ExecTask{
+		Command: "inlets-pro",
+		Args: []string{
+			"server",
+			"--token=" + inletsToken,
+			"--common-name=" + eth,
+			"--auto-tls=true",
+		},
+	}
+
+	serverRes, serverErr := serverTask.Execute()
+
+	if serverErr != nil {
+		return fmt.Errorf("error with server: %s", serverErr.Error())
+	}
+
+	if serverRes.ExitCode != 0 {
+		return fmt.Errorf("exit code unexpected from inlets server: %d, stderr: %s, stdout: %s", serverRes.ExitCode, serverRes.Stderr, serverRes.Stdout)
+
+	}
+
+	return nil
+}
+
 func runKfwd(cmd *cobra.Command, _ []string) error {
+
 	ns, err := cmd.Flags().GetString("namespace")
 	if err != nil {
 		return err
@@ -79,6 +164,18 @@ func runKfwd(cmd *cobra.Command, _ []string) error {
 		return passwordErr
 	}
 
+	if pro, _ := cmd.Flags().GetBool("pro"); pro {
+		license, err := cmd.Flags().GetString("license")
+		if err != nil {
+			return err
+		}
+		if len(license) == 0 {
+			return fmt.Errorf("--license is required for use with inlets PRO, get a free trial at inlets.dev")
+		}
+
+		return fwdPro(cmd, eth, port, upstream, ns, inletsToken, license)
+	}
+
 	deployment := makeDeployment(eth, port, upstream, ns, inletsToken)
 	tmpPath := path.Join(os.TempDir(), "inlets-"+upstream+".yaml")
 	err = ioutil.WriteFile(tmpPath, []byte(deployment), 0600)
@@ -92,7 +189,6 @@ func runKfwd(cmd *cobra.Command, _ []string) error {
 		Args:    []string{"apply", "-f", tmpPath},
 	}
 	res, err := task.Execute()
-
 	if err != nil {
 		return err
 	}
@@ -133,7 +229,8 @@ func runKfwd(cmd *cobra.Command, _ []string) error {
 
 http://%s:%s
 
-Hit Control+C to cancel.`, eth, port)
+Hit Control+C to cancel.
+`, eth, port)
 
 	serverTask := v1.ExecTask{
 		Command: "inlets",
@@ -156,6 +253,38 @@ Hit Control+C to cancel.`, eth, port)
 	}
 
 	return nil
+}
+
+func makeProDeployment(remote, ports, upstream, ns, inletsToken, license string) string {
+
+	return fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inlets-pro-client
+  namespace: %s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: inlets-pro-client
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: inlets-pro-client
+    spec:
+      containers:
+      - name: inlets-pro-client
+        image: inlets/inlets-pro:0.7.0
+        imagePullPolicy: IfNotPresent
+        command: ["inlets-pro"]
+        args:
+        - "client"
+        - "--url=wss://%s:8123/connect"
+        - "--upstream=%s"
+        - "--ports=%s"
+        - "--token=%s"
+        - "--license=%s"
+`, ns, remote, upstream, ports, inletsToken, license)
 }
 
 func makeDeployment(remote, port, upstream, ns, inletsToken string) string {

--- a/cmd/kfwd.go
+++ b/cmd/kfwd.go
@@ -143,6 +143,7 @@ Hit Control+C to cancel.`, eth, port)
 			"--token=" + inletsToken,
 		},
 	}
+
 	serverRes, serverErr := serverTask.Execute()
 
 	if serverErr != nil {
@@ -176,7 +177,7 @@ spec:
     spec:
       containers:
       - name: inlets
-        image: inlets/inlets:2.7.2
+        image: inlets/inlets:2.7.4
         imagePullPolicy: IfNotPresent
         command: ["inlets"]
         args:


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description

Updates verbiage from exit-node to exit-server everywhere
Changes from inlets-pro to inlets PRO
Updates flags for compatibility with newer inlets PRO version,
see notes at:

https://github.com/inlets/inlets-pro/releases/tag/0.7.0


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

TBD once release is cut and uploaded.

## How are existing users impacted? What migration steps/scripts do we need?

Existing users will need to stop using the `--remote-tcp` flag, this is replaced with `--pro` and the client now specifies the upstream server with `--upstream`.
