### PR TITLE
Remove *.tgz.sha256 files from release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,21 +13,16 @@ deploy:
   file:
   - "./bin/inletsctl.tgz"
   - "./bin/inletsctl.sha256"
-  - "./bin/inletsctl.tgz.sha256"
   - "./bin/inletsctl-darwin.tgz"
-  - "./bin/inletsctl-freebsd.tgz"
-  - "./bin/inletsctl-freebsd.tgz.sha256"
   - "./bin/inletsctl-darwin.sha256"
-  - "./bin/inletsctl-darwin.tgz.sha256"
+  - "./bin/inletsctl-freebsd.tgz"
+  - "./bin/inletsctl-freebsd.sha256"
   - "./bin/inletsctl-armhf.tgz"
   - "./bin/inletsctl-armhf.sha256"
-  - "./bin/inletsctl-armhf.tgz.sha256"
   - "./bin/inletsctl-arm64.tgz"
   - "./bin/inletsctl-arm64.sha256"
-  - "./bin/inletsctl-arm64.tgz.sha256"
   - "./bin/inletsctl.exe.tgz"
   - "./bin/inletsctl.exe.sha256"
-  - "./bin/inletsctl.exe.tgz.sha256"
   skip_cleanup: true
   on:
     tags: true


### PR DESCRIPTION
Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

## Description
Removes all the tgz.sha256 files from release


## How are existing users impacted? What migration steps/scripts do we need?
No user impact

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
