### PR TITLE
Only upload .tgz and .sha265 files to release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,4 +19,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          asset_paths: '["./bin/*"]'
+          asset_paths: '["./uploads/*"]'

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GitCommit := $(shell git rev-parse HEAD)
 LDFLAGS := "-s -w -X main.Version=$(Version) -X main.GitCommit=$(GitCommit)"
 export GO111MODULE=on
 .PHONY: all
-all: gofmt test dist hashgen
+all: gofmt test dist compress hashgen
 
 .PHONY: test
 test:
@@ -16,10 +16,15 @@ gofmt:
 .PHONY: hashgen
 hashgen:
 	./ci/hashgen.sh
+
+.PHONY: compress
+compress:
+	./ci/compress.sh
 	
 .PHONY: dist
 dist:
 	mkdir -p bin/
+	mkdir -p uploads/
 	rm -rf bin/inlets*
 	CGO_ENABLED=0 GOOS=linux go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/inletsctl
 	CGO_ENABLED=0 GOOS=darwin go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/inletsctl-darwin
@@ -27,7 +32,3 @@ dist:
 	CGO_ENABLED=0 GOOS=freebsd go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/inletsctl-freebsd
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/inletsctl-armhf
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/inletsctl-arm64
-
-	echo "Compressing the compiled artifacts"
-	find bin -name "inletsctl*" -exec tar -cvzf {}.tgz {} \;
-

--- a/ci/compress.sh
+++ b/ci/compress.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd bin
+for f in inletsctl*; do tar -cvzf ../uploads/$f.tgz $f; done

--- a/ci/hashgen.sh
+++ b/ci/hashgen.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd bin
-for f in inletsctl*; do shasum -a 256 $f > $f.sha256; done
+for f in inletsctl*; do shasum -a 256 $f > ../uploads/$f.sha256; done


### PR DESCRIPTION
Fixes #85

Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

## Description
Reduces the number of files uploaded to Github release by only uploading the .tgz and .sha256 files to the release.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with this release:
https://github.com/utsavanand2/inletsctl/releases/tag/0.6.5

## How are existing users impacted? What migration steps/scripts do we need?
We have removed all the .tgz.sha256 and the uncompressed binaries from the release, so workflows depending on the tgz.sha256 (which is very unlikely), and users downloading the uncompressed binary will have to first download the compressed binary and then uncompress it and if necessary cross check and compare the SHA of the binary with respective one in the Github release.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
