### PR TITLE
Set flag pro by reading both --tcp and --pro

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -43,7 +43,8 @@ func init() {
 	createCmd.Flags().String("subscription-id", "", "Subscription ID (Azure)")
 
 	createCmd.Flags().Bool("tcp", true, `Provision an exit-server with inlets PRO running as a TCP server`)
-
+	createCmd.Flags().Bool("pro", true, `Provision an exit-server with inlets PRO (Deprecated)`)
+	_ = createCmd.Flags().MarkHidden("pro")
 	createCmd.Flags().DurationP("poll", "n", time.Second*2, "poll every N seconds, use a higher value if you encounter rate-limiting")
 }
 
@@ -190,10 +191,14 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	var pro bool
 
-	if v, _ := cmd.Flags().GetBool("pro"); v {
-		pro = true
+	pro := true
+	if cmd.Flags().Changed("pro") {
+		fmt.Printf("WARN: --pro is deprecated, use --tcp instead.")
+		pro, _ = cmd.Flags().GetBool("pro")
+	}
+	if cmd.Flags().Changed("tcp") {
+		pro, _ = cmd.Flags().GetBool("tcp")
 	}
 
 	name := strings.Replace(names.GetRandomName(10), "_", "-", -1)


### PR DESCRIPTION
The pro flag is used to enable pro-specific
options such as opening all ports. The --pro
command line arg is deprecated in favor
of --tcp. We keep both for now but will
remove --pro in the future.

Signed-off-by: Ze Chen <zechenbit@gmail.com>

## Description
Will fix #89


## How Has This Been Tested?
### Provision VM to run inlets-server in  Azure
```
create --provider=azure --subscription-id=ffffffffffffffffffff --region=eastus --access-token-file=client_credentials.json --pro
```
### Output
```
[82/500] Host: inlets-pedantic-dijkstra9|deployment-f7af6665-3949-4b87-bcf9-343960eaecd2, status: Running
[83/500] Host: inlets-pedantic-dijkstra9|deployment-f7af6665-3949-4b87-bcf9-343960eaecd2, status: active
inlets PRO (0.8.1) exit-server summary:
  IP: 40.114.94.81
  Auth-token: XNYxykHfVpo1ToMFwgtmjCt0wUe9slhKFcvZGxibmMX0iwQ9r007z0TgvM1ePLJC

Command:

# Obtain a license at https://inlets.dev
export LICENSE="$HOME/.inlets/license"

# Give a single value or comma-separated
export PORTS="8000"

# Where to route traffic from the inlets serverx
export UPSTREAM="localhost"

inlets-pro client --url "wss://40.114.94.81:8123/connect" \
  --token "XNYxykHfVpo1ToMFwgtmjCt0wUe9slhKFcvZGxibmMX0iwQ9r007z0TgvM1ePLJC" \
  --license-file "$LICENSE" \
  --upstream $UPSTREAM \
  --ports $PORTS

To delete:
  inletsctl delete --provider azure --id "inlets-pedantic-dijkstra9|deployment-f7af6665-3949-4b87-bcf9-343960eaecd2"
```

### Client was able to connect server.
```
➜  inlets inlets-pro client --url "wss://40.114.94.81:8123/connect" \
  --token "XNYxykHfVpo1ToMFwgtmjCt0wUe9slhKFcvZGxibmMX0iwQ9r007z0TgvM1ePLJC" \
  --license-file "$LICENSE" \
  --upstream $UPSTREAM \
  --ports $PORTS

2021/02/17 23:54:11 Starting TCP client. Version 0.8.0-dirty - 7d2137f283e67490d64ea68903f7d49b9c9463c3
2021/02/17 23:54:11 Licensed to: Ze Chen ******
2021/02/17 23:54:11 Upstream server: 192.168.101.100, for ports: ****
inlets-pro client. Copyright Alex Ellis, OpenFaaS Ltd 2020
INFO[2021/02/17 23:54:12] Connecting to proxy                           url="wss://40.114.94.81:8123/connect"
```


## How are existing users impacted? What migration steps/scripts do we need?
No impact.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
