### PR TITLE
Add HTTPS tunnel support for create command

### DIFF
--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) Inlets Author(s) 2019. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package cmd
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func Test_MakeHTTPSUserdata_OneDomain(t *testing.T) {
+	got := MakeHTTPSUserdata("token", "0.8.4", "contact@example.com", "prod", []string{"example.com"})
+	ioutil.WriteFile("/tmp/t.txt", []byte(got), 0600)
+	want := `#!/bin/bash
+export AUTHTOKEN="token"
+export IP=$(curl -sfSL https://checkip.amazonaws.com)
+
+curl -SLsf https://github.com/inlets/inlets-pro/releases/download/0.8.4/inlets-pro -o /tmp/inlets-pro && \
+  chmod +x /tmp/inlets-pro  && \
+  mv /tmp/inlets-pro /usr/local/bin/inlets-pro
+
+curl -SLsf https://github.com/inlets/inlets-pro/releases/download/0.8.4/inlets-pro-http.service -o inlets-pro.service && \
+  mv inlets-pro.service /etc/systemd/system/inlets-pro.service && \
+  echo "AUTHTOKEN=$AUTHTOKEN" >> /etc/default/inlets-pro && \
+  echo "IP=$IP" >> /etc/default/inlets-pro && \
+  echo "DOMAINS=--letsencrypt-domain=example.com" >> /etc/default/inlets-pro && \
+  echo "ISSUER=--letsencrypt-issuer=prod" >> /etc/default/inlets-pro && \
+  echo "EMAIL=--letsencrypt-email=contact@example.com" >> /etc/default/inlets-pro && \
+  systemctl daemon-reload && \
+  systemctl start inlets-pro && \
+  systemctl enable inlets-pro
+`
+	if want != got {
+		t.Fatalf("want\n%s\nbut got\n%s\n", want, got)
+	}
+}
+
+func Test_MakeHTTPSUserdata_TwoDomains(t *testing.T) {
+	got := MakeHTTPSUserdata("token", "0.8.4", "contact@example.com", "prod",
+		[]string{"a.example.com", "b.example.com"})
+
+	ioutil.WriteFile("/tmp/t.txt", []byte(got), 0600)
+	want := `#!/bin/bash
+export AUTHTOKEN="token"
+export IP=$(curl -sfSL https://checkip.amazonaws.com)
+
+curl -SLsf https://github.com/inlets/inlets-pro/releases/download/0.8.4/inlets-pro -o /tmp/inlets-pro && \
+  chmod +x /tmp/inlets-pro  && \
+  mv /tmp/inlets-pro /usr/local/bin/inlets-pro
+
+curl -SLsf https://github.com/inlets/inlets-pro/releases/download/0.8.4/inlets-pro-http.service -o inlets-pro.service && \
+  mv inlets-pro.service /etc/systemd/system/inlets-pro.service && \
+  echo "AUTHTOKEN=$AUTHTOKEN" >> /etc/default/inlets-pro && \
+  echo "IP=$IP" >> /etc/default/inlets-pro && \
+  echo "DOMAINS=--letsencrypt-domain=a.example.com --letsencrypt-domain=b.example.com" >> /etc/default/inlets-pro && \
+  echo "ISSUER=--letsencrypt-issuer=prod" >> /etc/default/inlets-pro && \
+  echo "EMAIL=--letsencrypt-email=contact@example.com" >> /etc/default/inlets-pro && \
+  systemctl daemon-reload && \
+  systemctl start inlets-pro && \
+  systemctl enable inlets-pro
+`
+	if want != got {
+		t.Fatalf("want\n%s\nbut got\n%s\n", want, got)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description

Add HTTPS tunnel support for create command

This enables fast HTTPS tunnels to be provisioned.   

## How Has This Been Tested?

Tested with the staging issuer and a custom domain. This relies 
on a new service file, which will be published with each new 
inlets PRO binary release.

inlets-pro-http.service is fetched and the defaults file is 
populated with the Let's Encrypt data such as domain, email 
and issuer.

```bash
mkdir -p $GOPATH/src/github.com/inlets/
cd $GOPATH/src/github.com/inlets/
git clone https://github.com/inlets/inletsctl --branch=https-tunnels
cd inletsctl

# Change to "prod" or remove `--letsencrypt-issuer` to use the default
export ISSUER=staging

go build && ./inletsctl create \
  --letsencrypt-domain site1.alex.o6s.io \
  --letsencrypt-email contact@o6s.io \
  --letsencrypt-issuer staging \
  --access-token-file ~/.secrets/access-token
```

I've tested `staging`, I'd like someone else to leave that flag off, which should default to `prod`.

I then ran: `doctl compute domain create site1.alex.o6s.io --ip-address 138.68.190.75` as fast as I could.

I connected a PythonSimpleHTTP server to the tunnel with the printed-out client command from inletsctl

![staging-cert](https://user-images.githubusercontent.com/6358735/112361705-97534a80-8ccb-11eb-9d7a-e44f1c554b89.png)

## How are existing users impacted? What migration steps/scripts do we need?

Create will always provision TCP tunnels, unless the `--letsencrypt-*` flags are given.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
