### PR TITLE
Vultr: update Ubuntu version due to deprecation of 16.04

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -478,13 +478,14 @@ func createHost(provider, name, region, zone, projectID, userData, inletsPort st
 	} else if provider == "vultr" {
 		// OS:
 		//  A complete list of available OS is available using: https://api.vultr.com/v1/os/list
-		//  215 = Ubuntu 16.04 x64
+		//  387 = Ubuntu 20.04 x64
 		// Plans:
 		//  A complete list of available OS is available using: https://api.vultr.com/v1/plans/list
 		//  201 = 1024 MB RAM,25 GB SSD,1.00 TB BW
+		const ubuntu20_04_x64 = "387"
 		return &provision.BasicHost{
 			Name:       name,
-			OS:         "215",
+			OS:         ubuntu20_04_x64,
 			Plan:       "201",
 			Region:     region,
 			UserData:   userData,


### PR DESCRIPTION
Signed-off-by: Johan Siebens <johan.siebens@gmail.com>

## Description

Update Ubuntu images to 18.04 for the Vultr provider

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Create the inlets exit node:

```
$ go run main.go create -p vultr --access-token "$VULTR_TOKEN"
Using provider: vultr
Requesting host: crazy-cray7 in LHR, from vultr
Host: 48732398, status: 
[1/500] Host: 48732398, status: none
[2/500] Host: 48732398, status: none
...
[204/500] Host: 48732398, status: active
inlets PRO TCP (0.8.3) server summary:
  IP: 136.244.64.63
  Auth-token: vQGanZLGBjleE4IacZc1TGDkL2c9JPImBotrclYl01DxC8ssKq2vLIRkwa1o8lVc
...
```
Connect client:

```
$ inlets-pro tcp client --url "wss://136.244.64.63:8123" \
>   --token "vQGanZLGBjleE4IacZc1TGDkL2c9JPImBotrclYl01DxC8ssKq2vLIRkwa1o8lVc" \
>   --upstream $UPSTREAM \
>   --ports $PORTS
2021/07/06 19:57:35 Starting TCP client. Version 0.8.3 - 205c311fde775723cf68b8116dacd7f428d243f8
2021/07/06 19:57:35 Licensed to: Johan Siebens <redacted>, expires: 85 day(s)
2021/07/06 19:57:35 Upstream server: localhost, for ports: 8000
inlets-pro client. Copyright Alex Ellis, OpenFaaS Ltd 2020
INFO[2021/07/06 19:57:35] Connecting to proxy                           url="wss://136.244.64.63:8123/connect"
```


## How are existing users impacted? What migration steps/scripts do we need?

no impact

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
No unit tests exist for most other providers and there's not much logic.