### PR TITLE
Linode: update Ubuntu version due to deprecation of 16.04

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -136,6 +136,8 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 		region = "hel1"
 	} else if provider == "vultr" {
 		region = "LHR" // London
+	} else if provider == "linode" {
+		region = "eu-west"
 	}
 
 	var zone string
@@ -493,13 +495,13 @@ func createHost(provider, name, region, zone, projectID, userData, inletsPort st
 	} else if provider == "linode" {
 		// Image:
 		//  List of images can be retrieved using: https://api.linode.com/v4/images
-		//  Example response: .."id": "linode/ubuntu16.04lts", "label": "Ubuntu 16.04 LTS"..
+		//  Example response: .."id": "linode/ubuntu20.04", "label": "Ubuntu 20.04 LTS"..
 		// Type:
 		//  Type is the VM plan / size in linode.
 		//  List of type and price can be retrieved using curl https://api.linode.com/v4/linode/types
 		return &provision.BasicHost{
 			Name:     name,
-			OS:       "linode/ubuntu16.04lts",
+			OS:       "linode/ubuntu20.04",
 			Plan:     "g6-nanode-1",
 			Region:   region,
 			UserData: userData,


### PR DESCRIPTION
Signed-off-by: Johan Siebens <johan.siebens@gmail.com>

## Description

- Update Ubuntu images to 18.04 for the Linode provider
- Set default region for Linode

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Create the inlets exit node:

```
go run main.go create -p linode --access-token $LINODE_TOKEN
Using provider: linode
Requesting host: cranky-swanson6 in eu-west, from linode
Host: 28305085, status: provisioning
[1/500] Host: 28305085, status: provisioning
...
[27/500] Host: 28305085, status: active
inlets PRO TCP (0.8.3) server summary:
  IP: 178.79.130.30
  Auth-token: lvsSgN9Fe3NXfJyu2KkwF17TXdgcjJWYseZzbHceUQz85ZL7A2dUGEhhyW6pQdnx
```

Connect client:
```
$ inlets-pro tcp client --url "wss://178.79.130.30:8123" \
>   --token "lvsSgN9Fe3NXfJyu2KkwF17TXdgcjJWYseZzbHceUQz85ZL7A2dUGEhhyW6pQdnx" \
>   --upstream $UPSTREAM \
>   --ports $PORTS
2021/07/06 20:16:47 Starting TCP client. Version 0.8.3 - 205c311fde775723cf68b8116dacd7f428d243f8
2021/07/06 20:16:47 Licensed to: Johan Siebens <redacted>, expires: 85 day(s)
2021/07/06 20:16:47 Upstream server: localhost, for ports: 8000
```
## How are existing users impacted? What migration steps/scripts do we need?

no impact

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
No unit tests exist for most other providers and there's not much logic.