### PR TITLE
Scaleway: update Ubuntu version due to deprecation of 16.04 (bionic)

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -401,7 +401,7 @@ func createHost(provider, name, region, zone, projectID, userData, inletsPort st
 	} else if provider == "scaleway" {
 		return &provision.BasicHost{
 			Name:       name,
-			OS:         "ubuntu-bionic",
+			OS:         "ubuntu-focal",
 			Plan:       "DEV1-S",
 			Region:     region,
 			UserData:   userData,


### PR DESCRIPTION
Signed-off-by: Johan Siebens <johan.siebens@gmail.com>

## Description

Update Ubuntu images to 18.04 for the Scaleway provider

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Create the inlets exit node:
```
$ go run main.go create -p scaleway --access-token $SCALEWAY_TOKEN --secret-key $SCALEWAY_SECRET_KEY --organisation-id $SCALEWAY_ORG
Using provider: scaleway
Requesting host: nifty-lumiere9 in fr-par-1, from scaleway
2021/07/06 20:55:18 Provisioning host with Scaleway
Host: 56059386-f1c5-48cc-a13b-72c197755da2, status: stopped
[1/500] Host: 56059386-f1c5-48cc-a13b-72c197755da2, status: starting
...
[11/500] Host: 56059386-f1c5-48cc-a13b-72c197755da2, status: active
inlets PRO TCP (0.8.3) server summary:
  IP: 212.47.249.11
  Auth-token: GO48cfuQ33JzDtHiMzBCymWALTtvJlnl5wbeTDeBMwKNXiTTPPO3P3fWdRw8S4N7
```
Connect client:

```
$ inlets-pro tcp client --url "wss://212.47.249.11:8123" \
>   --token "GO48cfuQ33JzDtHiMzBCymWALTtvJlnl5wbeTDeBMwKNXiTTPPO3P3fWdRw8S4N7" \
>   --upstream $UPSTREAM \
>   --ports $PORTS
2021/07/06 20:57:12 Starting TCP client. Version 0.8.3 - 205c311fde775723cf68b8116dacd7f428d243f8
2021/07/06 20:57:12 Licensed to: Johan Siebens <redacted>, expires: 85 day(s)
2021/07/06 20:57:12 Upstream server: localhost, for ports: 8000
inlets-pro client. Copyright Alex Ellis, OpenFaaS Ltd 2020
INFO[2021/07/06 20:57:12] Connecting to proxy                           url="wss://212.47.249.11:8123/connect"

```
## How are existing users impacted? What migration steps/scripts do we need?

no impact

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
No unit tests exist for most other providers and there's not much logic.