### PR TITLE
Accommodate Session Tokens for ec2

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -26,6 +26,9 @@ func init() {
 
 	deleteCmd.Flags().String("secret-key", "", "The access token for your cloud (scaleway, ec2)")
 	deleteCmd.Flags().String("secret-key-file", "", "Read this file for the access token for your cloud (scaleway, ec2)")
+	deleteCmd.Flags().String("session-token", "", "The session token for ec2 (when using with temporary credentials)")
+	deleteCmd.Flags().String("session-token-file", "", "Read this file for the session token for ec2 (when using with temporary credentials)")
+
 	deleteCmd.Flags().String("organisation-id", "", "Organisation ID (scaleway)")
 	deleteCmd.Flags().String("project-id", "", "Project ID (equinix-metal, gce)")
 	deleteCmd.Flags().String("subscription-id", "", "Subscription ID (azure)")
@@ -79,6 +82,7 @@ func runDelete(cmd *cobra.Command, _ []string) error {
 	}
 
 	var secretKey string
+	var sessionToken string
 	var organisationID string
 	if provider == "scaleway" || provider == "ec2" {
 		var secretKeyErr error
@@ -89,6 +93,14 @@ func runDelete(cmd *cobra.Command, _ []string) error {
 		)
 		if secretKeyErr != nil {
 			return secretKeyErr
+		}
+
+		if provider == "ec2" {
+			var sessionTokenErr error
+			sessionToken, sessionTokenErr = getFileOrString(cmd.Flags(), "session-token-file", "session-token", false)
+			if sessionTokenErr != nil {
+				return sessionTokenErr
+			}
 		}
 
 		if provider == "scaleway" {
@@ -104,7 +116,7 @@ func runDelete(cmd *cobra.Command, _ []string) error {
 		subscriptionID, _ = cmd.Flags().GetString("subscription-id")
 	}
 
-	provisioner, err := getProvisioner(provider, accessToken, secretKey, organisationID, region, subscriptionID)
+	provisioner, err := getProvisioner(provider, accessToken, secretKey, organisationID, region, subscriptionID, sessionToken)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description

Adds the capability for users to use temporary credentials when using ec2.  To do this there needed to be provision for the session token to be passed.  This has been added both as a CLI parameter and a file (following the same pattern as the Access key and secret key).

When calling `getFileOrString` for  sessionToken the required flag is necessarily set to false owing to the fact that if the user is using long lived creds then the sessionToken is not required. 

Although testing shows `get-session-token` it is anticipated that the majority of users would use `assume-role` to generate these temporary credentials.

Fixes #103 

## How Has This Been Tested?
* Get some temporary credentials:

```
$ TEMPORARY_CREDENTIALS=$(aws sts get-session-token --profile=<profile_name>)
```

* Break the interesting parts out:

```
$ echo $TEMPORARY_CREDENTIALS | jq -r .Credentials.AccessKeyId > access-key.txt    
$ echo $TEMPORARY_CREDENTIALS | jq -r .Credentials.SecretAccessKey > secret-key.txt
$ echo $TEMPORARY_CREDENTIALS | jq -r .Credentials.SessionToken > session-token.txt
```

* Use the three temporary credential parts to create an exit node:
```
$ ./inletsctl-darwin create \                                          
  --provider ec2 \
  --region eu-west-1 \
  --access-token-file ./access-key.txt \
  --secret-key-file ./secret-key.txt \
  --session-token-file ./session-token.txt
Using provider: ec2
Requesting host: modest-bardeen4 in eu-west-1, from ec2
Host: i-09f4426d8cab1e845, status: creating
[1/500] Host: i-09f4426d8cab1e845, status: creating
[2/500] Host: i-09f4426d8cab1e845, status: creating
[3/500] Host: i-09f4426d8cab1e845, status: initialising
...
[91/500] Host: i-09f4426d8cab1e845, status: initialising
[92/500] Host: i-09f4426d8cab1e845, status: active
inlets PRO TCP (0.8.3) server summary:
  IP: 54.229.67.251
  Auth-token: eSF0JwpKVfZ4F51ptilX2zWzxUR3FxF7YlcvEzRy8lAdBhf7pgrLzwXTzY8PcMWp

Command:

# Obtain a license at https://inlets.dev
# Store it at $HOME/.inlets/LICENSE or use --help for more options
export LICENSE="$HOME/.inlets/LICENSE"

# Give a single value or comma-separated
export PORTS="8000"

# Where to route traffic from the inlets server
export UPSTREAM="localhost"

inlets-pro tcp client --url "wss://54.229.67.251:8123" \
  --token "eSF0JwpKVfZ4F51ptilX2zWzxUR3FxF7YlcvEzRy8lAdBhf7pgrLzwXTzY8PcMWp" \
  --upstream $UPSTREAM \
  --ports $PORTS

To delete:
  inletsctl delete --provider ec2 --id "i-09f4426d8cab1e845"

```

* connect the exit node to the upstream

```
$ inlets-pro tcp client --url "wss://54.229.67.251:8123" --token "eSF0JwpKVfZ4F51ptilX2zWzxUR3FxF7YlcvEzRy8lAdBhf7pgrLzwXTzY8PcMWp" --upstream localhost --ports 8080 --license-file pro.lic
2021/07/17 14:45:10 Starting TCP client. Version 0.8.5 - 8db64ded51b1455cf4ad027c52bc9cfbeb55c4b3
2021/07/17 14:45:10 Licensed to: Richard Gee <contact@openfaas.com>, expires: 14 day(s)
2021/07/17 14:45:10 Upstream server: localhost, for ports: 8080
inlets-pro client. Copyright Alex Ellis, OpenFaaS Ltd 2020
INFO[2021/07/17 14:45:11] Connecting to proxy                           url="wss://54.229.67.251:8123/connect"
INFO[2021/07/17 14:45:11] Connection established.. OK.
```

Confirmed local site was accessible via the public IP address

* Delete the ec2 using the existing temporary credentials

```
$ ./inletsctl-darwin delete \
  --provider ec2 \                                                                           
  --id "i-09f4426d8cab1e845" \
  --access-token-file ./access-key.txt \
  --secret-key-file ./secret-key.txt \
  --session-token-file ./session-token.txt
Using provider: ec2
Deleting host: i-09f4426d8cab1e845 from ec2
```

* Create the same again but this time use CLI values, rather than files

```
$ ./inletsctl-darwin create \
  --provider ec2 \
  --region eu-west-1 \
  --access-token $(cat ./access-key.txt) \
  --secret-key $(cat ./secret-key.txt) \ 
  --session-token $(cat ./session-token.txt) 
Using provider: ec2
Requesting host: hopeful-liskov4 in eu-west-1, from ec2
Host: i-0455b7272cae015e4, status: creating
[1/500] Host: i-0455b7272cae015e4, status: creating
[2/500] Host: i-0455b7272cae015e4, status: creating
[3/500] Host: i-0455b7272cae015e4, status: initialising
...
[75/500] Host: i-0455b7272cae015e4, status: initialising
[76/500] Host: i-0455b7272cae015e4, status: active
inlets PRO TCP (0.8.3) server summary:
  IP: 3.250.217.11
  Auth-token: NQFSWj7qRnEnjCkys4dbYML5FiCKQqoATazhj2ukJ6A1v8uczYbQUhtG6A39GvSQ

Command:

# Obtain a license at https://inlets.dev
# Store it at $HOME/.inlets/LICENSE or use --help for more options
export LICENSE="$HOME/.inlets/LICENSE"

# Give a single value or comma-separated
export PORTS="8000"

# Where to route traffic from the inlets server
export UPSTREAM="localhost"

inlets-pro tcp client --url "wss://3.250.217.11:8123" \
  --token "NQFSWj7qRnEnjCkys4dbYML5FiCKQqoATazhj2ukJ6A1v8uczYbQUhtG6A39GvSQ" \
  --upstream $UPSTREAM \
  --ports $PORTS

To delete:
  inletsctl delete --provider ec2 --id "i-0455b7272cae015e4"
```

* Join the exit node to the upstream
```
$ inlets-pro tcp client --url "wss://3.250.217.11:8123" --token "NQFSWj7qRnEnjCkys4dbYML5FiCKQqoATazhj2ukJ6A1v8uczYbQUhtG6A39GvSQ" --upstream localhost --ports 8080 --license-file pro.lic
2021/07/17 15:02:49 Starting TCP client. Version 0.8.5 - 8db64ded51b1455cf4ad027c52bc9cfbeb55c4b3
2021/07/17 15:02:49 Licensed to: Richard Gee <contact@openfaas.com>, expires: 14 day(s)
2021/07/17 15:02:49 Upstream server: localhost, for ports: 8080
inlets-pro client. Copyright Alex Ellis, OpenFaaS Ltd 2020
INFO[2021/07/17 15:02:50] Connecting to proxy                           url="wss://3.250.217.11:8123/connect"
INFO[2021/07/17 15:02:50] Connection established.. OK. 
```

Confirmed local site was accessible via the public IP address

* Delete the ec2 using the existing temporary credentials using CLI values, rather than files

```
 ./inletsctl-darwin delete \ 
  --provider ec2 \
  --id "i-0455b7272cae015e4" \
  --access-token $(cat ./access-key.txt) \
  --secret-key $(cat ./secret-key.txt) \
  --session-token $(cat ./session-token.txt)
Using provider: ec2
Deleting host: i-0455b7272cae015e4 from ec2
```

* Try long lived variables to check existing operation in unaffected:

```
$ cat > ./access-key.txt 

$ cat > ./secret-key.txt 
 
$ rm ./session-token.txt 
$ ./inletsctl-darwin create \
  --provider ec2 \                                                                   
  --region eu-west-1 \
  --access-token $(cat ./access-key.txt) \
  --secret-key $(cat ./secret-key.txt)  
Using provider: ec2
Requesting host: nostalgic-lamarr8 in eu-west-1, from ec2
Host: i-04464f06789ed6160, status: creating
[1/500] Host: i-04464f06789ed6160, status: creating
[2/500] Host: i-04464f06789ed6160, status: creating
[3/500] Host: i-04464f06789ed6160, status: creating
[4/500] Host: i-04464f06789ed6160, status: creating
[5/500] Host: i-04464f06789ed6160, status: initialising
...
[91/500] Host: i-04464f06789ed6160, status: initialising
[92/500] Host: i-04464f06789ed6160, status: active
inlets PRO TCP (0.8.3) server summary:
  IP: 54.246.198.197
  Auth-token: AjdBCvOGk8YmIk10ah0b0J5muCeDoLslYU4qZtuoZiap1mzw3hYi3DKRfnxElMtw

Command:

# Obtain a license at https://inlets.dev
# Store it at $HOME/.inlets/LICENSE or use --help for more options
export LICENSE="$HOME/.inlets/LICENSE"

# Give a single value or comma-separated
export PORTS="8000"

# Where to route traffic from the inlets server
export UPSTREAM="localhost"

inlets-pro tcp client --url "wss://54.246.198.197:8123" \
  --token "AjdBCvOGk8YmIk10ah0b0J5muCeDoLslYU4qZtuoZiap1mzw3hYi3DKRfnxElMtw" \
  --upstream $UPSTREAM \
  --ports $PORTS

To delete:
  inletsctl delete --provider ec2 --id "i-04464f06789ed6160"
```

* Join the exit node to the upstream
```
inlets-pro tcp client --url "wss://54.246.198.197:8123" --token "AjdBCvOGk8YmIk10ah0b0J5muCeDoLslYU4qZtuoZiap1mzw3hYi3DKRfnxElMtw" --upstream localhost --ports 8080 --license-file pro.lic
2021/07/17 15:29:34 Starting TCP client. Version 0.8.5 - 8db64ded51b1455cf4ad027c52bc9cfbeb55c4b3
2021/07/17 15:29:34 Licensed to: Richard Gee <contact@openfaas.com>, expires: 14 day(s)
2021/07/17 15:29:34 Upstream server: localhost, for ports: 8080
inlets-pro client. Copyright Alex Ellis, OpenFaaS Ltd 2020
INFO[2021/07/17 15:29:34] Connecting to proxy                           url="wss://54.246.198.197:8123/connect"
INFO[2021/07/17 15:29:34] Connection established.. OK. 
```

* Confirmed local site was accessible via the public IP address

* Delete the ec2 using the long lived credentials 
 
```
 ./inletsctl-darwin delete \
  --provider ec2 \                                                                   
  --id "i-04464f06789ed6160" \
  --access-token-file ./access-key.txt \  
  --secret-key-file ./secret-key.txt         
Using provider: ec2
Deleting host: i-04464f06789ed6160 from ec2
```

* Confirmed in the AWS Console that all instances have been destroyed.



## How are existing users impacted? What migration steps/scripts do we need?
Existing users should notice no impact.  This change adds the option to use temporary credentials as well as the existing long lived variant.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required) https://github.com/inlets/docs/pull/18
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
