### PR TITLE
add extra flag to override default plan or size of the exit-node

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -28,6 +28,7 @@ func init() {
 
 	createCmd.Flags().StringP("provider", "p", "digitalocean", "The cloud provider - digitalocean, gce, ec2, azure, equinix-metal, scaleway, linode, civo, hetzner or vultr")
 	createCmd.Flags().StringP("region", "r", "lon1", "The region for your cloud provider")
+	createCmd.Flags().StringP("plan", "s", "", "The plan or size for your cloud instance")
 	createCmd.Flags().StringP("zone", "z", "us-central1-a", "The zone for the exit-server (gce)")
 
 	createCmd.Flags().StringP("inlets-token", "t", "", "The auth token for the inlets server on your new exit-server, leave blank to auto-generate")
@@ -259,6 +260,15 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 
 	if err != nil {
 		return err
+	}
+
+	// override default plan/size when provided
+	if cmd.Flags().Changed("plan") {
+		planOverride, err := cmd.Flags().GetString("plan")
+		if err != nil {
+			return errors.Wrap(err, "failed to get 'plan' value")
+		}
+		hostReq.Plan = planOverride
 	}
 
 	if provider == "gce" {


### PR DESCRIPTION
## Description

This PR adds an additional flag to override the default plan or size of the exit node

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Successfully created an exit node with a different plan, e.g. Scaleway Stardust:

```
$ go run main.go create -p scaleway --region=nl-ams-1 --plan=STARDUST1-S ...
Using provider: scaleway
Requesting host: strange-wiles1 in nl-ams-1, from scaleway
Host: d1622777-0c3e-4a03-975c-6825e42d9163, status: stopped
[1/500] Host: d1622777-0c3e-4a03-975c-6825e42d9163, status: starting
[2/500] Host: d1622777-0c3e-4a03-975c-6825e42d9163, status: starting
...
[18/500] Host: d1622777-0c3e-4a03-975c-6825e42d9163, status: active
inlets PRO TCP (0.8.3) server summary:
  IP: 51.158.189.204
  Auth-token: JoWxVv7yBuOH7BEEEZIzItd9EPENIifZtAIHJWe11n6oMSFN797wy3bXroRpzSxG
```

Connect client:

```
$ inlets-pro tcp client --url "wss://51.158.189.204:8123" \
>   --token "JoWxVv7yBuOH7BEEEZIzItd9EPENIifZtAIHJWe11n6oMSFN797wy3bXroRpzSxG" \
>   --upstream $UPSTREAM \
>   --ports $PORTS
2021/07/19 21:37:10 Starting TCP client. Version 0.8.5 - 8db64ded51b1455cf4ad027c52bc9cfbeb55c4b3
2021/07/19 21:37:10 Licensed to: Johan Siebens <redacted>, expires: 72 day(s)
2021/07/19 21:37:10 Upstream server: localhost, for ports: 8000
inlets-pro client. Copyright Alex Ellis, OpenFaaS Ltd 2020
INFO[2021/07/19 21:37:10] Connecting to proxy                           url="wss://51.158.189.204:8123/connect"
INFO[2021/07/19 21:37:10] Connection established.. OK.               
```

## How are existing users impacted? What migration steps/scripts do we need?

no impact

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
