### PR TITLE
Fix download command with Apple Silicon machines

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -226,7 +226,11 @@ func buildFilename(arch, osVal string) (string, string) {
 	}
 
 	if osVal == "darwin" {
-		arch = "-" + osVal
+		if arch == "arm64" {
+			arch = "-" + osVal + "-" + arch
+		} else {
+			arch = "-" + osVal
+		}
 	} else if arch == "amd64" {
 		arch = ""
 	} else {

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -46,3 +46,12 @@ func Test_BuildFilename_Darwin_amd64(t *testing.T) {
 		t.Errorf("want: %s, but got: %s", want, arch+ext)
 	}
 }
+
+func Test_BuildFilename_Darwin_arm64(t *testing.T) {
+	arch, ext := buildFilename("arm64", "darwin")
+	want := "-darwin-arm64"
+
+	if want != arch+ext {
+		t.Errorf("want: %s, but got: %s", want, arch+ext)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Zespre Schmidt <starbops@zespre.com>

## Description

Related issue: #121

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I built a dev version of inletsctl and tested on my M1 machine:

```bash
$ sudo ./bin/inletsctl-darwin-arm64 download -v
Password:
2023/02/01 16:23:09 https://github.com/inlets/inlets-pro/releases/tag/0.9.13
URL: https://github.com/inlets/inlets-pro/releases/download/0.9.13/inlets-pro-darwin-arm64.
Starting download of inlets-pro 0.9.13, this could take a few moments.
Download completed, make sure that /usr/local/bin is on your path. 
  inlets-pro version

$ /usr/local/bin/inlets-pro version                            
 _       _      _            _
(_)_ __ | | ___| |_ ___   __| | _____   __
| | '_ \| |/ _ \ __/ __| / _` |/ _ \ \ / /
| | | | | |  __/ |_\__ \| (_| |  __/\ V /
|_|_| |_|_|\___|\__|___(_)__,_|\___| \_/

  inlets (tm) - Cloud Native Tunnels
Version: 0.9.13 - 90e5c951334923b4d6d97628be054eb6c39a6170
```

## How are existing users impacted? What migration steps/scripts do we need?

No impact.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
