### PR TITLE
Update default OS and plan for Hetzner and DigitalOcean

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -450,8 +450,8 @@ func createHost(provider, name, region, zone, projectID, userData, inletsProCont
 	if provider == "digitalocean" {
 		return &provision.BasicHost{
 			Name:       name,
-			OS:         "ubuntu-22-04-x64",
-			Plan:       "s-1vcpu-1gb",
+			OS:         "debian-13-x64",
+			Plan:       "s-1vcpu-512mb-10gb",
 			Region:     region,
 			UserData:   userData,
 			Additional: map[string]string{},
@@ -587,7 +587,7 @@ func createHost(provider, name, region, zone, projectID, userData, inletsProCont
 			Name:     name,
 			Region:   region,
 			Plan:     "cx23",
-			OS:       "ubuntu-22.04",
+			OS:       "debian-13",
 			UserData: userData,
 		}, nil
 	}


### PR DESCRIPTION
## Description

Update the default OS image for Hetzner from ubuntu-22.04 to debian-13.
Update the default OS image for DigitalOcean from ubuntu-22-04-x64 to debian-13-x64 and the plan from s-1vcpu-1gb to s-1vcpu-512mb-10gb.

## How Has This Been Tested?

Exit nodes on Hetzner and DigitalOcean with the updated instance types were tested with the inlets-operator which switched to the same default types.

## How are existing users impacted? What migration steps/scripts do we need?

Existing users will get the updated OS and plan defaults when creating new exit nodes. No migration is needed — this only affects newly provisioned hosts.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests