### PR TITLE
Update inlets-pro version to 0.11.14

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -21,7 +21,7 @@ import (
 
 // AE: Find version with the following:
 // crane ls ghcr.io/inlets/inlets-pro |tail -n 1
-const inletsProDefaultVersion = "0.11.13"
+const inletsProDefaultVersion = "0.11.14"
 const inletsProControlPort = 8123
 
 func init() {


### PR DESCRIPTION
## Description

Bump the default inlets-pro release used by inletsctl to 0.11.14 for hardened auto-TLS support.

## How Has This Been Tested?

Tested against Hetzner with TCP tunnels:

- Deployed current inletsctl default 0.11.13 and verified inlets-pro 0.11.14 client fails without `--auto-tls-legacy`
- Verified inlets-pro 0.11.14 client connects to the 0.11.13 server with `--auto-tls-legacy`
- Deployed patched inletsctl default 0.11.14 and verified inlets-pro 0.11.14 client connects without `--auto-tls-legacy`

## How are existing users impacted? What migration steps/scripts do we need?

New servers created by inletsctl will use inlets-pro 0.11.14 by default. Existing servers are not changed and should be recreated or upgraded to get hardened auto-TLS support.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests